### PR TITLE
[codex] Update Snowpipe streaming auth and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See a [video](https://youtu.be/zX3K-rfNZIU) for a general overview.
 - Snowflake account/role with permission to create/use the target database, schema, and pipe
 - Azure Event Hub namespace with read access (consumer group) and either `az login` or a connection string
 - Ability to run OpenSSL to generate RSA keys for Snowflake key-pair auth
-- `snowsql` (or Snowflake UI) to truncate tables/checkpoints when testing from scratch
+- Snowflake CLI `snow` (or Snowflake UI) to test key-pair auth and query Snowflake
 
 ## Install
 
@@ -75,6 +75,7 @@ SNOWFLAKE_WAREHOUSE=compute_wh
 SNOWFLAKE_DATABASE=INGESTION
 SNOWFLAKE_SCHEMA_NAME=PUBLIC
 SNOWFLAKE_ROLE=STREAM
+SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
 
 # Control Table (for checkpointing)
 TARGET_DB=CONTROL
@@ -118,6 +119,21 @@ Generate RSA key pair for authentication:
 # Example: ALTER USER STREAMEV SET RSA_PUBLIC_KEY='MIIBIjANBgkqhki...';
 ```
 
+Test the same RSA key with Snowflake CLI:
+
+```bash
+snow connection test \
+  --account "$SNOWFLAKE_ACCOUNT" \
+  --user "$SNOWFLAKE_USER" \
+  --authenticator SNOWFLAKE_JWT \
+  --private-key-path "$SNOWFLAKE_PRIVATE_KEY_FILE"
+```
+
+The `SNOWFLAKE_JWT` authenticator is required for private-key authentication.
+EvSnow passes `SNOWFLAKE_PRIVATE_KEY_FILE` and `SNOWFLAKE_PRIVATE_KEY_PASSWORD`
+directly to the Snowpipe Streaming SDK. It does not write an unencrypted copy
+of the private key to a temporary file.
+
 ### Azure authentication
 
 For Event Hub consumption, EvSnow uses `EVENTHUBNAME_{N}_CONNECTION_STRING` when it is set. Otherwise it uses the Azure CLI identity from `az login`; that identity needs `Azure Event Hubs Data Receiver` on the Event Hub or namespace.
@@ -156,8 +172,23 @@ When starting the pipeline **without existing checkpoints** (e.g., after truncat
 
 ```bash
 # Example: Starting fresh after truncating tables
-snowsql -q "truncate table ingestion.public.events_table1;"
-snowsql -q "truncate table control.public.ingestion_status;"
+snow sql -x \
+  --account "$SNOWFLAKE_ACCOUNT" \
+  --user "$SNOWFLAKE_USER" \
+  --authenticator SNOWFLAKE_JWT \
+  --private-key-file "$SNOWFLAKE_PRIVATE_KEY_FILE" \
+  --role "$SNOWFLAKE_ROLE" \
+  --warehouse "$SNOWFLAKE_WAREHOUSE" \
+  -q "TRUNCATE TABLE ingestion.public.events_table1;"
+
+snow sql -x \
+  --account "$SNOWFLAKE_ACCOUNT" \
+  --user "$SNOWFLAKE_USER" \
+  --authenticator SNOWFLAKE_JWT \
+  --private-key-file "$SNOWFLAKE_PRIVATE_KEY_FILE" \
+  --role "$SNOWFLAKE_ROLE" \
+  --warehouse "$SNOWFLAKE_WAREHOUSE" \
+  -q "TRUNCATE TABLE control.public.ingestion_status;"
 
 # Consumer will process based on STARTING_POSITION_ON_NO_CHECKPOINT setting
 uv run evsnow run
@@ -240,7 +271,9 @@ Get your token at [logfire.pydantic.dev](https://logfire.pydantic.dev)
 
 ### Snowpipe Streaming Configuration
 
-The pipeline uses Snowflake's high-performance Snowpipe Streaming SDK (requires PIPE object):
+The pipeline uses Snowflake's high-performance Snowpipe Streaming SDK with a
+PIPE object. The checked-in lockfile currently resolves `snowpipe-streaming` to
+`1.4.0`.
 
 ```bash
 # Add to .env
@@ -251,6 +284,10 @@ SNOWFLAKE_SCHEMA_NAME=PUBLIC
 ```
 
 One PIPE serves the target table, while EvSnow opens one Snowpipe Streaming channel per Event Hub partition. A batch containing mixed partitions is split before ingestion, sorted by sequence number within each partition, and sent to channels named `<base-channel>-p<sanitized-partition>`.
+
+Version `1.4.0` adds OAuth and Programmatic Access Token support in the SDK.
+EvSnow still defaults to JWT/RSA key-pair auth because that keeps the runtime
+configuration simple and works with Snowflake trial accounts.
 
 Dependencies are managed through `pyproject.toml` and the checked-in `uv.lock`. Use `uv sync --locked` when you need the exact locked versions, and refresh the lock only when intentionally changing dependencies.
 

--- a/SNOWFLAKE_COMPLETE_SETUP.md
+++ b/SNOWFLAKE_COMPLETE_SETUP.md
@@ -31,6 +31,7 @@ Before starting, make sure you have:
 | ✅ Azure CLI | Authenticated with `az login` |
 | ✅ Python 3.13+ | With `uv` package manager |
 | ✅ Snowflake Account | With ACCOUNTADMIN access (for initial setup) |
+| ✅ Snowflake CLI | The `snow` command for key-pair auth checks |
 | ✅ Azure Event Hub | Namespace and topic configured |
 | ✅ Azure Storage Account | Optional, only for customer-managed external-volume Iceberg |
 | ✅ DuckDB (optional) | For direct Iceberg queries |
@@ -82,6 +83,10 @@ This creates two files in the `snowflake/` directory:
 | `rsa_key_pub_value.txt` | Public key (for Snowflake) | — |
 
 > 💡 **Tip**: Remember the password you set! You'll need it for `SNOWFLAKE_PRIVATE_KEY_PASSWORD` in your `.env` file.
+
+EvSnow passes the encrypted private-key file and passphrase directly to the
+Snowpipe Streaming SDK. It does not create an unencrypted temporary private-key
+file during startup.
 
 ### Verify the keys were created
 
@@ -298,6 +303,7 @@ ICEBERG_VERSION = 3;
 ### 4.2 Create the Streaming Pipe
 
 > ⚠️ **Important**: The high-performance Snowpipe Streaming SDK **requires** a PIPE object.
+> The checked-in EvSnow lockfile currently uses `snowpipe-streaming` `1.4.0`.
 
 ```sql
 CREATE OR REPLACE PIPE EVENTS_TABLE_PIPE AS
@@ -418,8 +424,19 @@ USE_HYBRID_TABLE=false
 # Install dependencies
 uv sync
 
+# Test Snowflake key-pair authentication
+set -a
+source .env
+set +a
+
+snow connection test \
+  --account "$SNOWFLAKE_ACCOUNT" \
+  --user "$SNOWFLAKE_USER" \
+  --authenticator SNOWFLAKE_JWT \
+  --private-key-path "$SNOWFLAKE_PRIVATE_KEY_FILE"
+
 # Validate your configuration
-uv run python src/main.py validate-config
+uv run evsnow validate-config --show-rbac
 ```
 
 > ✅ You should see all checks passing.
@@ -434,26 +451,68 @@ uv run python src/main.py validate-config
 
 ```bash
 # Normal run
-uv run python src/main.py run
+uv run evsnow run
 
 # Dry run (no actual data ingestion)
-uv run python src/main.py run --dry-run
+uv run evsnow run --dry-run
 
 # With smart retry enabled
-uv run python src/main.py run --smart
+uv run evsnow run --smart
 ```
 
 ### Monitor Status
 
 ```bash
 # Check pipeline status
-uv run python src/main.py status
+uv run evsnow status
 
 # Show version
-uv run python src/main.py version
+uv run evsnow version
 ```
 
 > 🎉 **Success**: Events from your Event Hub topic are now streaming into the Snowflake Iceberg table!
+
+### Send and Check a Small Batch
+
+For a quick end-to-end check, start EvSnow in one shell:
+
+```bash
+SNOWFLAKE_1_BATCH=3 uv run evsnow run
+```
+
+Then send three messages from another shell:
+
+```bash
+RUN_ID="evsnow-smoke-$(date -u +%Y%m%dT%H%M%SZ)"
+START_ID=$(date -u +%s)
+
+uv run python tools/eventhub_sender/main.py \
+  --count 3 \
+  --start-id "$START_ID" \
+  --batch-size 3 \
+  --partition-key "$RUN_ID" \
+  --payload "{\"run_id\":\"$RUN_ID\",\"purpose\":\"arrival-check\"}"
+```
+
+Check Snowflake for the same `run_id`:
+
+```bash
+snow sql -x \
+  --account "$SNOWFLAKE_ACCOUNT" \
+  --user "$SNOWFLAKE_USER" \
+  --authenticator SNOWFLAKE_JWT \
+  --private-key-file "$SNOWFLAKE_PRIVATE_KEY_FILE" \
+  --role "$SNOWFLAKE_ROLE" \
+  --warehouse "$SNOWFLAKE_WAREHOUSE" \
+  --database "$SNOWFLAKE_1_DATABASE" \
+  --schema "$SNOWFLAKE_1_SCHEMA" \
+  --format JSON \
+  -q "SELECT COUNT(*) AS rows_arrived
+      FROM ${SNOWFLAKE_1_DATABASE}.${SNOWFLAKE_1_SCHEMA}.${SNOWFLAKE_1_TABLE}
+      WHERE TRY_PARSE_JSON(EVENT_BODY):payload:run_id::STRING = '$RUN_ID';"
+```
+
+For this smoke test, `rows_arrived` should be `3`.
 
 ---
 
@@ -701,8 +760,8 @@ storage instead of the default Snowflake-managed internal storage.
 - [ ] Created Iceberg table `EVENTS_TABLE1`
 - [ ] Created Pipe `EVENTS_TABLE_PIPE`
 - [ ] Configured `.env` file
-- [ ] Validated config with `uv run python src/main.py validate-config`
-- [ ] Started pipeline with `uv run python src/main.py run`
+- [ ] Validated config with `uv run evsnow validate-config --show-rbac`
+- [ ] Started pipeline with `uv run evsnow run`
 
 ---
 

--- a/SNOWFLAKE_QUICKSTART.md
+++ b/SNOWFLAKE_QUICKSTART.md
@@ -4,6 +4,9 @@ This guide will walk you through setting up EvSnow to connect to Snowflake in 6 
 
 Official detailed documentation is available in [Snowflake key-pair authentication docs](https://docs.snowflake.com/en/user-guide/key-pair-auth).
 
+EvSnow uses Snowpipe Streaming through the checked-in `uv.lock`. The current
+lock resolves `snowpipe-streaming` to `1.4.0`.
+
 ## Prerequisites
 
 - Snowflake account with appropriate permissions (ACCOUNTADMIN or equivalent)
@@ -39,7 +42,7 @@ Run the automated key generation script:
 
 ### Step 2: Assign Public Key to Snowflake User
 
-1. Log into Snowflake (Web UI or SnowSQL)
+1. Log into Snowflake (Web UI or Snowflake CLI)
 2. Run this SQL command (replace placeholders):
 
 ```sql
@@ -273,6 +276,7 @@ SNOWFLAKE_WAREHOUSE=COMPUTE_WH                   # Your warehouse name
 SNOWFLAKE_DATABASE=MYDB                          # Your database
 SNOWFLAKE_SCHEMA_NAME=PUBLIC                     # Connection/default schema
 SNOWFLAKE_ROLE=DATA_ENGINEER                     # Optional: your role
+SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE            # Pipe created in Step 4
 
 # Control table configuration
 TARGET_DB=MYDB                                   # Database for control table
@@ -294,7 +298,24 @@ SNOWFLAKE_1_BATCH=1000                           # Batch size (leave as-is)
 
 ### Step 6: Verify Configuration
 
-Validate the environment file and RBAC guidance:
+First, test the RSA key with Snowflake CLI:
+
+```bash
+set -a
+source .env
+set +a
+
+snow connection test \
+  --account "$SNOWFLAKE_ACCOUNT" \
+  --user "$SNOWFLAKE_USER" \
+  --authenticator SNOWFLAKE_JWT \
+  --private-key-path "$SNOWFLAKE_PRIVATE_KEY_FILE"
+```
+
+Private-key authentication requires `--authenticator SNOWFLAKE_JWT`. Without it,
+Snowflake CLI will reject the connection before it reaches Snowflake.
+
+Then validate the environment file and RBAC guidance:
 
 ```bash
 uv run evsnow validate-config --show-rbac
@@ -323,6 +344,7 @@ uv run evsnow validate-config
 **What this does:**
 
 - Tests Snowflake connection using key-pair authentication
+- Passes the encrypted private-key file and passphrase directly to the Snowpipe Streaming SDK
 - Creates the `INGESTION_STATUS` hybrid table (if it doesn't exist)
 - Verifies permissions
 
@@ -397,7 +419,16 @@ GRANT INSERT, SELECT, UPDATE ON TABLE <TARGET_DB>.<TARGET_SCHEMA>.INGESTION_STAT
 ### Still having issues?
 
 1. Check configuration and RBAC guidance: `uv run evsnow validate-config --show-rbac`
-2. Verify Snowflake connectivity: `snowsql -a <account> -u <user> --private-key-path snowflake/rsa_key_encrypted.p8`
+2. Verify Snowflake connectivity:
+
+   ```bash
+   snow connection test \
+     --account "$SNOWFLAKE_ACCOUNT" \
+     --user "$SNOWFLAKE_USER" \
+     --authenticator SNOWFLAKE_JWT \
+     --private-key-path "$SNOWFLAKE_PRIVATE_KEY_FILE"
+   ```
+
 3. Check the full setup guide: [snowflake_setup.md](./snowflake_setup.md)
 
 ## Key Files Reference
@@ -423,6 +454,9 @@ GRANT INSERT, SELECT, UPDATE ON TABLE <TARGET_DB>.<TARGET_SCHEMA>.INGESTION_STAT
    ```bash
    chmod 600 snowflake/rsa_key_encrypted.p8
    ```
+
+   Keep the key encrypted. EvSnow and Snowpipe Streaming SDK `1.4.0` can read
+   the encrypted key file with `SNOWFLAKE_PRIVATE_KEY_PASSWORD`.
 
 3. **Rotate keys regularly:**
    - Generate new keys every 90 days

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evsnow"
-version = "0.1.0"
+version = "0.1.1"
 description = "EvSnow - Azure EventHub to Snowflake streaming pipeline"
 readme = "README.md"
 authors = [

--- a/snowflake_setup.md
+++ b/snowflake_setup.md
@@ -6,7 +6,7 @@ Set up key-pair authentication for EvSnow using RSA keys (JWT).
 
 - OpenSSL installed
 - Snowflake account with a role that can set user keys
-- Ability to run SQL in Snowflake (Snowsight or SnowSQL)
+- Ability to run SQL in Snowflake (Snowsight or Snowflake CLI `snow`)
 
 ## 1) Generate RSA keys (PKCS#8, encrypted)
 
@@ -35,15 +35,18 @@ USE ROLE ACCOUNTADMIN;
 ALTER USER <your_username> SET RSA_PUBLIC_KEY='<public_key_value>';
 ```
 
-## 4) Test authentication with SnowSQL
+## 4) Test authentication with Snowflake CLI
 
 ```bash
-snowsql -a <account_identifier> \
-        -u <username> \
-        --private-key-path rsa_key_encrypted.p8 \
-        -w <warehouse> -d <database> -s <schema>
-# Prompts for the key password
+snow connection test \
+  --account <account_identifier> \
+  --user <username> \
+  --authenticator SNOWFLAKE_JWT \
+  --private-key-path rsa_key_encrypted.p8
 ```
+
+Private-key authentication requires `SNOWFLAKE_JWT`. EvSnow uses the same key
+file through `SNOWFLAKE_PRIVATE_KEY_FILE`.
 
 ## 5) Configure EvSnow
 
@@ -58,12 +61,17 @@ SNOWFLAKE_WAREHOUSE=COMPUTE_WH
 SNOWFLAKE_DATABASE=MYDB
 SNOWFLAKE_SCHEMA_NAME=PUBLIC
 SNOWFLAKE_ROLE=DATA_ENGINEER
+SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
 ```
+
+EvSnow passes the encrypted private-key file and
+`SNOWFLAKE_PRIVATE_KEY_PASSWORD` directly to Snowpipe Streaming SDK `1.4.0`.
+It does not create an unencrypted temporary private-key file.
 
 Then validate:
 
 ```bash
-uv run evsnow validate-config
+uv run evsnow validate-config --show-rbac
 ```
 
 ## Checkpoint table (INGESTION_STATUS)

--- a/src/evsnow/__init__.py
+++ b/src/evsnow/__init__.py
@@ -1,6 +1,6 @@
 """EvSnow - Azure EventHub to Snowflake streaming pipeline."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def main() -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -672,7 +672,7 @@ def monitor(
 @app.command()
 def version() -> None:
     """Show version information."""
-    console.print("EvSnow v0.1.0")
+    console.print("EvSnow v0.1.1")
     console.print("EventHub to Snowflake streaming pipeline")
     console.print("\nComponents:")
     console.print("  • Azure EventHub async consumer with custom checkpointing")

--- a/src/streaming/factory.py
+++ b/src/streaming/factory.py
@@ -36,7 +36,7 @@ def create_snowflake_client(
     """
     Create a Snowflake High-Performance streaming client.
 
-    Uses the High-Performance Snowpipe Streaming SDK (v1.0.2+) with PIPE objects
+    Uses the High-Performance Snowpipe Streaming SDK with PIPE objects
     for maximum throughput (~10 GB/s per table).
 
     Reference: https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-getting-started

--- a/src/streaming/snowflake_high_performance.py
+++ b/src/streaming/snowflake_high_performance.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import logfire
 
-# Snowflake High-Performance Streaming SDK (v1.1.0+)
+# Snowflake High-Performance Streaming SDK
 from snowflake.ingest.streaming import StreamingIngestClient
 from snowflake.ingest.streaming.channel_status import ChannelStatus
 
@@ -96,59 +96,40 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
         """
         Build connection profile for StreamingIngestClient.
 
-        For the NEW high-performance architecture (v1.0.2+), the profile requires:
+        For the high-performance architecture, the profile requires:
         - user: Snowflake username
         - account: Account identifier (e.g., "ZZZZUUUU-YU88540")
         - url: Full Snowflake URL with port
-        - private_key_file: Path to PEM private key file (we write temp file in start())
+        - private_key_file: Path to PEM private key file
+        - private_key_passphrase: Optional passphrase for encrypted private keys
         - role: Role to use (optional)
 
         IMPORTANT: The profile does NOT include:
         - warehouse, database, schema (passed to StreamingIngestClient constructor instead)
         - host (use full 'url' instead)
-        - private_key content (use 'private_key_file' path instead)
 
         Reference:
-        https://docs.snowflake.com/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-getting-started
+        https://docs.snowflake.com/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-configurations
 
         Returns a dictionary with connection parameters including private key authentication.
         """
         logger.info("Building Snowflake connection profile for high-performance SDK")
 
         try:
-            # Load and decrypt private key to write to temp file later
-            from cryptography.hazmat.backends import default_backend
-            from cryptography.hazmat.primitives import serialization
-
             private_key_path = Path(self.connection_config.private_key_file).expanduser().resolve()
+            if not private_key_path.is_file():
+                raise FileNotFoundError(f"Private key file not found: {private_key_path}")
 
-            with private_key_path.open("rb") as key_file:
-                key_data = key_file.read()
-
-            # Decrypt the private key if password is provided
-            password = None
-            if self.connection_config.private_key_password:
-                password = self.connection_config.private_key_password.encode()
-
-            private_key_obj = serialization.load_pem_private_key(
-                key_data, password=password, backend=default_backend()
-            )
-
-            # Convert to unencrypted PEM format (high-performance SDK requires unencrypted key file)
-            private_key_pem = private_key_obj.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.PKCS8,
-                encryption_algorithm=serialization.NoEncryption(),  # No encryption for high-performance SDK
-            ).decode("utf-8")
-
-            # Build simplified profile for HIGH-PERFORMANCE SDK (v1.0.2+)
-            # Reference: https://docs.snowflake.com/user-guide/snowpipe-streaming/snowpipe-streaming-high-performance-getting-started
             profile = {
+                "authorization_type": "JWT",
                 "user": self.connection_config.user,
                 "account": self.connection_config.account,
                 "url": f"https://{self.connection_config.account}.snowflakecomputing.com:443",
-                "private_key": private_key_pem,  # Will write to temp file in start() and replace with path
+                "private_key_file": str(private_key_path),
             }
+
+            if self.connection_config.private_key_password:
+                profile["private_key_passphrase"] = self.connection_config.private_key_password
 
             # Add role if specified
             if self.connection_config.role:
@@ -183,53 +164,41 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
                 # Build connection profile
                 profile = self._build_connection_profile()
 
-                # Create StreamingIngestClient using HIGH-PERFORMANCE SDK (v1.0.2+)
-                # Reference: https://gist.github.com/sfc-gh-chathomas/a7b06bb46907bead737954d53b3a8495
+                # Create StreamingIngestClient using the high-performance SDK.
                 client_name = f"evsnow_{self.client_name_suffix}"
                 logger.info(f"Creating High-Performance StreamingIngestClient: {client_name}")
 
-                private_key_pem = profile.pop("private_key")  # Remove from profile dict
+                pipe_name = self.connection_config.pipe_name
+                if not pipe_name:
+                    raise ValueError(
+                        "pipe_name is required for high-performance streaming. "
+                        "Set SNOWFLAKE_PIPE_NAME environment variable."
+                    )
 
-                from utils.snowflake import temporary_private_key_file, temporary_profile_file
+                self.streaming_client = StreamingIngestClient(
+                    client_name=client_name,
+                    db_name=self.snowflake_config.database,
+                    schema_name=self.snowflake_config.schema_name,
+                    pipe_name=pipe_name,
+                    properties=profile,
+                )
 
-                with temporary_private_key_file(private_key_pem) as key_path:
-                    profile["private_key_file"] = key_path
-                    with temporary_profile_file(profile) as profile_path:
-                        pipe_name = self.connection_config.pipe_name
-                        if not pipe_name:
-                            raise ValueError(
-                                "pipe_name is required for high-performance streaming. "
-                                "Set SNOWFLAKE_PIPE_NAME environment variable."
-                            )
-
-                        self.streaming_client = StreamingIngestClient(
-                            client_name=client_name,
-                            db_name=self.snowflake_config.database,
-                            schema_name=self.snowflake_config.schema_name,
-                            pipe_name=pipe_name,
-                            profile_json=profile_path,  # Pass file path, not JSON string
-                        )
-
-                        logger.info(
-                            f"✅ High-Performance StreamingIngestClient created: {client_name}"
-                        )
-                        logfire.info(
-                            "Snowflake StreamingIngestClient initialized (high-performance SDK v1.0.2+)",
-                            client_name=client_name,
-                            database=self.snowflake_config.database,
-                            schema=self.snowflake_config.schema_name,
-                            pipe=pipe_name,
-                            table=self.snowflake_config.table_name,
-                        )
+                logger.info(f"✅ High-Performance StreamingIngestClient created: {client_name}")
+                logfire.info(
+                    "Snowflake StreamingIngestClient initialized",
+                    client_name=client_name,
+                    database=self.snowflake_config.database,
+                    schema=self.snowflake_config.schema_name,
+                    pipe=pipe_name,
+                    table=self.snowflake_config.table_name,
+                )
 
                 # Ensure target table exists
                 self._ensure_target_table()
 
                 self.stats["client_created_at"] = datetime.now(UTC)
                 self._last_client_refresh_at = self.stats["client_created_at"]
-                logger.info(
-                    "✅ Snowflake streaming client started successfully (high-performance SDK v1.0.2+)"
-                )
+                logger.info("✅ Snowflake streaming client started successfully")
 
             except Exception as e:
                 logger.error(f"Failed to start Snowflake streaming client: {e}", exc_info=True)

--- a/tests/unit/IMPLEMENTATION_SUMMARY.md
+++ b/tests/unit/IMPLEMENTATION_SUMMARY.md
@@ -84,8 +84,19 @@ sys.modules['tenacity'] = MagicMock()
 ### Fixture-Based Mocking
 Configuration objects provided via fixtures:
 - Mock classes with `model_copy()` method for pydantic compatibility
-- Temporary file creation for private key validation
+- Temporary private-key fixture paths for validation
 - Realistic test data
+
+High-performance Snowpipe Streaming client tests now assert the current SDK
+startup shape:
+
+- `StreamingIngestClient(..., properties=profile)`
+- `authorization_type="JWT"`
+- `private_key_file=<resolved key path>`
+- optional `private_key_passphrase`
+
+They should not expect `profile_json` files or unencrypted temporary private-key
+files.
 
 ### Patch-Based Mocking
 Per-test mocking using `@patch`:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -87,7 +87,7 @@ class TestVersionCommand:
         result = cli_runner.invoke(app, ["version"])
 
         assert result.exit_code == 0
-        assert "EvSnow v0.1.0" in self._strip_ansi(result.stdout)
+        assert "EvSnow v0.1.1" in self._strip_ansi(result.stdout)
         assert "EventHub to Snowflake streaming pipeline" in result.stdout
         assert "Azure EventHub async consumer" in result.stdout
 

--- a/tests/unit/test_snowflake_client.py
+++ b/tests/unit/test_snowflake_client.py
@@ -11,13 +11,7 @@ This module tests the SnowflakeHighPerformanceStreamingClient class including:
 - Statistics tracking
 """
 
-import os
-import sys
-import tempfile
-import types
-from contextlib import contextmanager
 from datetime import UTC, datetime
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -27,39 +21,6 @@ from streaming.snowflake_high_performance import (
     create_snowflake_streaming_client,
 )
 from utils.config import SnowflakeConnectionConfig
-
-
-def _install_snowflake_tempfile_stub(mocker) -> None:
-    """Install a light utils.snowflake stub for start() temp-file tests."""
-    module = types.ModuleType("utils.snowflake")
-
-    @contextmanager
-    def temporary_private_key_file(_private_key_pem: str):
-        import os
-        import tempfile
-
-        fd, path = tempfile.mkstemp(suffix=".pem", prefix="snowflake_key_")
-        os.close(fd)
-        try:
-            yield path
-        finally:
-            os.unlink(path)
-
-    @contextmanager
-    def temporary_profile_file(_profile):
-        import os
-        import tempfile
-
-        fd, path = tempfile.mkstemp(suffix=".json", prefix="snowflake_profile_")
-        os.close(fd)
-        try:
-            yield path
-        finally:
-            os.unlink(path)
-
-    module.temporary_private_key_file = temporary_private_key_file
-    module.temporary_profile_file = temporary_profile_file
-    mocker.patch.dict(sys.modules, {"utils.snowflake": module})
 
 
 class TestSnowflakeHighPerformanceStreamingClient:
@@ -190,28 +151,20 @@ class TestSnowflakeHighPerformanceStreamingClient:
             connection_config=sample_snowflake_connection_config,
         )
 
-        # Mock private key file content
-        mock_key_content = b"-----BEGIN PRIVATE KEY-----\ntest_key_data\n-----END PRIVATE KEY-----"
-        mock_private_key = mocker.MagicMock()
-        mock_private_key.private_bytes.return_value = mock_key_content
-
-        mocker.patch("pathlib.Path.open", mocker.mock_open(read_data=mock_key_content))
-        mocker.patch(
-            "cryptography.hazmat.primitives.serialization.load_pem_private_key",
-            return_value=mock_private_key,
-        )
-
         # Act
         profile = client._build_connection_profile()
 
         # Assert
+        assert profile["authorization_type"] == "JWT"
         assert profile["user"] == sample_snowflake_connection_config.user
         assert profile["account"] == sample_snowflake_connection_config.account
         assert (
             profile["url"]
             == f"https://{sample_snowflake_connection_config.account}.snowflakecomputing.com:443"
         )
-        assert "private_key" in profile
+        assert profile["private_key_file"] == sample_snowflake_connection_config.private_key_file
+        assert "private_key" not in profile
+        assert "private_key_passphrase" not in profile
         assert profile["role"] == sample_snowflake_connection_config.role
 
     def test_build_connection_profile_with_encrypted_key(
@@ -244,30 +197,13 @@ class TestSnowflakeHighPerformanceStreamingClient:
             connection_config=connection_config,
         )
 
-        # Mock private key decryption
-        mock_key_content = (
-            b"-----BEGIN ENCRYPTED PRIVATE KEY-----\ntest\n-----END ENCRYPTED PRIVATE KEY-----"
-        )
-        mock_private_key = mocker.MagicMock()
-        mock_private_key.private_bytes.return_value = (
-            b"-----BEGIN PRIVATE KEY-----\ndecrypted\n-----END PRIVATE KEY-----"
-        )
-
-        mocker.patch("pathlib.Path.open", mocker.mock_open(read_data=mock_key_content))
-        mock_load_key = mocker.patch(
-            "cryptography.hazmat.primitives.serialization.load_pem_private_key",
-            return_value=mock_private_key,
-        )
-
         # Act
         profile = client._build_connection_profile()
 
         # Assert
-        assert "private_key" in profile
-        # Verify password was passed to load_pem_private_key
-        mock_load_key.assert_called_once()
-        call_args = mock_load_key.call_args
-        assert call_args[1]["password"] == b"test_password"
+        assert profile["private_key_file"] == str(key_file.resolve())
+        assert profile["private_key_passphrase"] == "test_password"
+        assert "private_key" not in profile
 
     def test_build_connection_profile_without_role(
         self,
@@ -295,17 +231,6 @@ class TestSnowflakeHighPerformanceStreamingClient:
         client = SnowflakeHighPerformanceStreamingClient(
             snowflake_config=sample_snowflake_config,
             connection_config=connection_config,
-        )
-
-        # Mock private key loading
-        mock_key_content = b"-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
-        mock_private_key = mocker.MagicMock()
-        mock_private_key.private_bytes.return_value = mock_key_content
-
-        mocker.patch("pathlib.Path.open", mocker.mock_open(read_data=mock_key_content))
-        mocker.patch(
-            "cryptography.hazmat.primitives.serialization.load_pem_private_key",
-            return_value=mock_private_key,
         )
 
         # Act
@@ -342,8 +267,7 @@ class TestSnowflakeHighPerformanceStreamingClient:
             connection_config=connection_config,
         )
 
-        # Mock file open to raise FileNotFoundError
-        mocker.patch("pathlib.Path.open", side_effect=FileNotFoundError("File not found"))
+        key_file.unlink()
 
         # Act & Assert
         with pytest.raises(ValueError, match="Cannot build Snowflake connection profile"):
@@ -360,7 +284,6 @@ class TestSnowflakeHighPerformanceStreamingClient:
         mock_snowflake_streaming_client,
         mock_logfire,
         mocker,
-        tmp_path,
     ):
         """Test that start() initializes the streaming client successfully."""
         # Arrange
@@ -368,28 +291,6 @@ class TestSnowflakeHighPerformanceStreamingClient:
             snowflake_config=sample_snowflake_config,
             connection_config=sample_snowflake_connection_config,
         )
-
-        # Mock private key handling
-        mock_key_content = b"-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
-        mock_private_key = mocker.MagicMock()
-        mock_private_key.private_bytes.return_value = mock_key_content
-
-        mocker.patch("pathlib.Path.open", mocker.mock_open(read_data=mock_key_content))
-        mocker.patch(
-            "cryptography.hazmat.primitives.serialization.load_pem_private_key",
-            return_value=mock_private_key,
-        )
-
-        # Mock tempfile creation under tmp_path while returning real file descriptors.
-        real_mkstemp = tempfile.mkstemp
-        mock_mkstemp = mocker.patch("tempfile.mkstemp")
-        mock_mkstemp.side_effect = lambda suffix, prefix: real_mkstemp(
-            suffix=suffix,
-            prefix=prefix,
-            dir=tmp_path,
-        )
-
-        _install_snowflake_tempfile_stub(mocker)
 
         # Mock StreamingIngestClient to prevent real instantiation
         mock_streaming_client_class = mocker.patch(
@@ -405,48 +306,26 @@ class TestSnowflakeHighPerformanceStreamingClient:
         assert client.streaming_client is not None
         assert client.stats["client_created_at"] is not None
         mock_streaming_client_class.assert_called_once()
+        _, kwargs = mock_streaming_client_class.call_args
+        assert "profile_json" not in kwargs
+        assert kwargs["properties"]["private_key_file"] == (
+            sample_snowflake_connection_config.private_key_file
+        )
 
-    def test_start_creates_temporary_files_and_cleans_up(
+    def test_start_passes_profile_as_inline_properties(
         self,
         sample_snowflake_config,
         sample_snowflake_connection_config,
         mock_snowflake_streaming_client,
         mock_logfire,
         mocker,
-        tmp_path,
     ):
-        """Test that start() creates and cleans up temporary files."""
+        """Test that start() passes profile properties directly to the SDK."""
         # Arrange
         client = SnowflakeHighPerformanceStreamingClient(
             snowflake_config=sample_snowflake_config,
             connection_config=sample_snowflake_connection_config,
         )
-
-        # Mock private key handling
-        mock_key_content = b"-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----"
-        mock_private_key = mocker.MagicMock()
-        mock_private_key.private_bytes.return_value = mock_key_content
-
-        mocker.patch("pathlib.Path.open", mocker.mock_open(read_data=mock_key_content))
-        mocker.patch(
-            "cryptography.hazmat.primitives.serialization.load_pem_private_key",
-            return_value=mock_private_key,
-        )
-
-        # Mock tempfile creation under tmp_path while returning real file descriptors.
-        real_mkstemp = tempfile.mkstemp
-        mock_mkstemp = mocker.patch("tempfile.mkstemp")
-        created_paths: list[str] = []
-
-        def mkstemp_in_tmp_path(suffix: str, prefix: str):
-            fd, path = real_mkstemp(suffix=suffix, prefix=prefix, dir=tmp_path)
-            created_paths.append(path)
-            return fd, path
-
-        mock_mkstemp.side_effect = mkstemp_in_tmp_path
-        _install_snowflake_tempfile_stub(mocker)
-        mock_close = mocker.spy(os, "close")
-        mock_unlink = mocker.spy(os, "unlink")
 
         # Mock StreamingIngestClient
         mock_streaming_client_class = mocker.patch(
@@ -457,13 +336,13 @@ class TestSnowflakeHighPerformanceStreamingClient:
         # Act
         client.start()
 
-        # Assert - verify temp files were created and cleaned up
-        assert mock_mkstemp.call_count == 2
-        assert mock_close.call_count >= 2
-        assert mock_unlink.call_count == 2
-        for path in created_paths:
-            mock_unlink.assert_any_call(path)
-            assert not Path(path).exists()
+        # Assert
+        _, kwargs = mock_streaming_client_class.call_args
+        assert kwargs["properties"]["authorization_type"] == "JWT"
+        assert kwargs["properties"]["private_key_file"] == (
+            sample_snowflake_connection_config.private_key_file
+        )
+        assert "profile_json" not in kwargs
 
     def test_start_with_error_calls_stop(
         self,

--- a/tools/eventhub_sender/README.md
+++ b/tools/eventhub_sender/README.md
@@ -5,7 +5,7 @@ Small Typer CLI to push sequentially numbered JSON messages to an Event Hub so y
 ## Usage
 
 ```bash
-uv run python tools/eventhub_sender/main.py send \
+uv run python tools/eventhub_sender/main.py \
   --eventhub my-hub \
   --namespace my-namespace.servicebus.windows.net \
   --count 100 \
@@ -18,12 +18,15 @@ Or use a connection string (env var supported):
 
 ```bash
 export AZURE_EVENTHUB_CONNECTION_STRING="Endpoint=sb://...;SharedAccessKey=..."
-uv run python tools/eventhub_sender/main.py send --eventhub my-hub --count 20
+uv run python tools/eventhub_sender/main.py --eventhub my-hub --count 20
 
 # If your .env already has EVENTHUB_NAMESPACE, EVENTHUBNAME_1, and AZURE_EVENTHUB_CONNECTION_STRING,
 # you can omit those flags and the CLI will pick them up automatically:
-uv run python tools/eventhub_sender/main.py send --count 20
+uv run python tools/eventhub_sender/main.py --count 20
 ```
+
+This Typer app is mounted as a single command. Pass options directly to
+`main.py`; do not add a `send` subcommand.
 
 ## Message shape
 
@@ -40,3 +43,48 @@ Each message is a JSON object:
 ```
 
 `sequence_id` increments monotonically from `--start-id` so you can detect missing ids after ingestion.
+
+## End-to-End Arrival Check
+
+Use a unique `run_id` when you want to verify that a small test batch reached
+Snowflake.
+
+```bash
+RUN_ID="evsnow-smoke-$(date -u +%Y%m%dT%H%M%SZ)"
+START_ID=$(date -u +%s)
+
+uv run python tools/eventhub_sender/main.py \
+  --count 3 \
+  --start-id "$START_ID" \
+  --batch-size 3 \
+  --partition-key "$RUN_ID" \
+  --payload "{\"run_id\":\"$RUN_ID\",\"purpose\":\"arrival-check\"}"
+```
+
+Then query the target table:
+
+```bash
+set -a
+source .env
+set +a
+
+snow sql -x \
+  --account "$SNOWFLAKE_ACCOUNT" \
+  --user "$SNOWFLAKE_USER" \
+  --authenticator SNOWFLAKE_JWT \
+  --private-key-file "$SNOWFLAKE_PRIVATE_KEY_FILE" \
+  --role "$SNOWFLAKE_ROLE" \
+  --warehouse "$SNOWFLAKE_WAREHOUSE" \
+  --database "$SNOWFLAKE_1_DATABASE" \
+  --schema "$SNOWFLAKE_1_SCHEMA" \
+  --format JSON \
+  -q "SELECT COUNT(*) AS rows_arrived,
+             LISTAGG(TRY_PARSE_JSON(EVENT_BODY):sequence_id::STRING, ',')
+               WITHIN GROUP (ORDER BY TRY_PARSE_JSON(EVENT_BODY):sequence_id::NUMBER)
+             AS sequence_ids
+      FROM ${SNOWFLAKE_1_DATABASE}.${SNOWFLAKE_1_SCHEMA}.${SNOWFLAKE_1_TABLE}
+      WHERE TRY_PARSE_JSON(EVENT_BODY):payload:run_id::STRING = '$RUN_ID';"
+```
+
+For a 3-message smoke test, `rows_arrived` should be `3` and the
+`sequence_ids` should be consecutive.

--- a/uv.lock
+++ b/uv.lock
@@ -197,15 +197,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.7.0"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -765,6 +765,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/6f/2adb571fda448d4afd2466e1cef2963fefdc6b37847da05249983e415f17/fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c", size = 3281842, upload-time = "2026-04-24T14:37:20.833Z" },
     { url = "https://files.pythonhosted.org/packages/17/07/4bad2e96c4c6bae40253be2573cc09c1e5b9ccf821e1ff74e0d33b64bf90/fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f", size = 450903, upload-time = "2026-04-24T14:37:23.059Z" },
     { url = "https://files.pythonhosted.org/packages/5b/b7/180f67ba9a46ba23a1ff6432f48d3087d4f2048579ecc262b00426cb1c63/fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a", size = 391076, upload-time = "2026-04-24T14:37:24.756Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/18f60329b627d2118a4a2b19e8741fbd807d60bf0470554e1bbfb7f1bca3/fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b", size = 1055430, upload-time = "2026-05-09T21:53:14.364Z" },
     { url = "https://files.pythonhosted.org/packages/d2/ac/a1fa1fc29df0efc89d4946a743b09bdc9500591b5b92083eaf8e93664916/fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa", size = 3503075, upload-time = "2026-04-24T14:37:26.826Z" },
     { url = "https://files.pythonhosted.org/packages/82/bf/4f669e10b6bc38a731ee3400aed1a1e2d0a3e3cf411e72f6b320d3af0eaf/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282", size = 3410900, upload-time = "2026-04-24T14:37:29.233Z" },
     { url = "https://files.pythonhosted.org/packages/10/39/ecb19fdae4158a7730b5963fbf1b6d38d74678392d73083be518642af0c1/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370", size = 3335637, upload-time = "2026-04-24T14:37:31.472Z" },
@@ -1116,11 +1117,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -2799,16 +2800,16 @@ wheels = [
 
 [[package]]
 name = "snowpipe-streaming"
-version = "1.2.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "msgspec" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/16/15cc9dbc0858aa68f7bdf0a53750d3a28390e878a4bec6453209adaa2d09/snowpipe_streaming-1.2.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:04524b44141225ab56203336ba4ed5fd554cb3efa041c5e69f8a1097a5abc6eb", size = 9708210, upload-time = "2026-02-16T20:47:58.732Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/cd/f522b64b5c8ec9224f3c50f52a22aa906db2f86cb1df2ba3beef9c5cada0/snowpipe_streaming-1.2.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d43d1f7ba3887b74ddf62510ed10c539891277017fec4156cd8ab07f0584f951", size = 10767588, upload-time = "2026-02-16T20:48:00.985Z" },
-    { url = "https://files.pythonhosted.org/packages/78/45/41e9347e769b3837670b1399357640f77cd572002db16c0f5588edf76273/snowpipe_streaming-1.2.0-cp39-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:68f96eba64e711a3934c8d9952c98f521df521a6c55b675ee44706b81dd02189", size = 11063083, upload-time = "2026-02-16T20:48:03.101Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/66/78f260de935297b8e1b1932db3dc342ba6bc98ad56c820e6282aaadc385d/snowpipe_streaming-1.2.0-cp39-abi3-win_amd64.whl", hash = "sha256:a408a1895ac48db00d3339d91c90e6ef2efb8847ca2049fd87eb8b35e41c9817", size = 8317926, upload-time = "2026-02-16T20:48:05.845Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/48/d39b0ab6aec57be9f944e04b4f5c3d7bfaa6aa8394d9a15da9e7bc8cd535/snowpipe_streaming-1.4.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:128ddc379e3c109e67840c029223b01596eb157792aea6b8f91599a138266531", size = 10005596, upload-time = "2026-05-08T17:37:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/24/3f/5aa29f9b277345d524f2d01e881e9ad1edd564d29aa850bdfec51ae66a83/snowpipe_streaming-1.4.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0339501dae7b8dc0007088d412d0fc758d30d4610c2c18cbe571c746d8ff228e", size = 11055536, upload-time = "2026-05-08T17:37:41.809Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7a/ddb7956d3694405c769c9c995a78f2d107aff27fa9a112ede1ae2b59da6d/snowpipe_streaming-1.4.0-cp39-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:cfc31cd0e76865dd4328e9b21255622d5ff704ad980bbbf366ea7af379d64a10", size = 11400034, upload-time = "2026-05-08T17:37:44.449Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0c/49566307022d37ae6231421ab158deb8807392af3678cfb2e44e7c18a260/snowpipe_streaming-1.4.0-cp39-abi3-win_amd64.whl", hash = "sha256:f0cc8515fbd218fe763c89aabb6cc57c139e7737b3c1e9b1867625ce5ec05808", size = 8834454, upload-time = "2026-05-08T17:37:46.98Z" },
 ]
 
 [[package]]
@@ -3062,11 +3063,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "evsnow"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Update the lockfile for the open security alerts: `urllib3`, `idna`, and `authlib`.
- Upgrade `snowpipe-streaming` to `1.4.0` and use the SDK `properties` profile with `private_key_file` and optional passphrase.
- Remove the old unencrypted temporary private-key handoff for the high-performance Snowpipe client.
- Refresh the Snowflake, sender, and test docs with current JWT auth, SDK version, and arrival-check commands.

## Validation

- `uv run pytest tests/unit/test_snowflake_client.py -q`
- `uv run pytest -q`
- `uv run ruff check src/streaming/snowflake_high_performance.py src/streaming/factory.py tests/unit/test_snowflake_client.py`
- `git diff --check`
- Markdown code-fence balance check for edited docs
- Live smoke: started `evsnow`, sent 3 Event Hub messages, and verified 3 Snowflake rows for the run id

## Notes

The staged safety scan found no `.env`, key files, literal tokens, or secret values. The hits were environment variable names, documented placeholders, and PyPI lockfile URLs/hashes.