### PR TITLE
[codex] Harden Event Hub to Snowflake pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,9 @@ EVENTHUBNAME_1_LOAD_BALANCING_STRATEGY=greedy
 EVENTHUBNAME_1_TRACK_LAST_ENQUEUED_EVENT_PROPERTIES=false
 
 # Azure EventHub Connection String (explicit alternative to Entra ID auth)
-# Get this from Azure Portal → Event Hubs Namespace → Shared access policies
+# Use a least-privilege Listen policy from Azure Portal -> Event Hubs Namespace -> Shared access policies.
 # The pipeline uses DefaultAzureCredential unless EVENTHUBNAME_{N}_CONNECTION_STRING is set.
-# EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://eventhub1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somekey"
+# EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://eventhub1.servicebus.windows.net/;SharedAccessKeyName=EvSnowListen;SharedAccessKey=<listen-key>"
 
 # ============================================================================
 # SNOWFLAKE CONNECTION SETTINGS

--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,12 @@ CONTROL_TABLE_BACKEND=snowflake
 # Hybrid tables are not available on trial accounts
 USE_HYBRID_TABLE=false
 
+# Partition ownership mode (default: durable)
+# durable: persist Event Hubs partition ownership in the configured control backend.
+# local_single_consumer_smoke: keep ownership in memory and persist only Snowflake
+# checkpoints. Use only for one local consumer when Hybrid Tables are unavailable.
+CONTROL_OWNERSHIP_MODE=durable
+
 # Postgres control table (only used when CONTROL_TABLE_BACKEND=postgres)
 CONTROL_PG_HOST=localhost
 CONTROL_PG_PORT=5432

--- a/.env.example
+++ b/.env.example
@@ -20,14 +20,28 @@ EVENTHUBNAME_1_CONSUMER_GROUP=$Default
 # Options:
 #   -1       = Start from BEGINNING (process all existing messages) - DEFAULT
 #   @latest  = Start from LATEST (only process new messages after connection)
-#   0        = Start from Event Hub offset 0 (not a synonym for earliest)
 # This only applies when starting fresh (no checkpoints). Normal operation resumes from saved checkpoints.
 EVENTHUBNAME_1_STARTING_POSITION_ON_NO_CHECKPOINT=-1
 
-# Event Hub connection string for the main receiver (optional)
-# If omitted, EvSnow uses Azure CLI auth from `az login`.
-# Use a least-privilege Listen policy, not RootManageSharedAccessKey.
-# EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://eventhub1.servicebus.windows.net/;SharedAccessKeyName=EvSnowListen;SharedAccessKey=<listen-key>"
+# Entra ID authentication and Event Hubs SDK options (optional)
+# DefaultAzureCredential is the production-capable default; use azure_cli only for explicit local/dev testing.
+EVENTHUBNAME_1_CREDENTIAL_MODE=default
+# EVENTHUBNAME_1_MANAGED_IDENTITY_CLIENT_ID=user-assigned-managed-identity-client-id
+EVENTHUBNAME_1_PREFETCH_COUNT=300
+EVENTHUBNAME_1_MAX_WAIT_TIME=60
+EVENTHUBNAME_1_RETRY_TOTAL=3
+EVENTHUBNAME_1_RETRY_BACKOFF_FACTOR=0.8
+EVENTHUBNAME_1_RETRY_BACKOFF_MAX=120
+EVENTHUBNAME_1_RETRY_MODE=exponential
+EVENTHUBNAME_1_LOAD_BALANCING_INTERVAL=30
+# EVENTHUBNAME_1_PARTITION_OWNERSHIP_EXPIRATION_INTERVAL=180
+EVENTHUBNAME_1_LOAD_BALANCING_STRATEGY=greedy
+EVENTHUBNAME_1_TRACK_LAST_ENQUEUED_EVENT_PROPERTIES=false
+
+# Azure EventHub Connection String (explicit alternative to Entra ID auth)
+# Get this from Azure Portal → Event Hubs Namespace → Shared access policies
+# The pipeline uses DefaultAzureCredential unless EVENTHUBNAME_{N}_CONNECTION_STRING is set.
+# EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://eventhub1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somekey"
 
 # ============================================================================
 # SNOWFLAKE CONNECTION SETTINGS

--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ To force Azure CLI-only auth for local testing, opt in explicitly:
 EVENTHUBNAME_1_CREDENTIAL_MODE=azure_cli
 ```
 
-Or provide a connection string in `.env`:
+Or provide a least-privilege Listen connection string in `.env`:
 
 ```bash
-EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://...;SharedAccessKey=..."
+EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=EvSnowListen;SharedAccessKey=<listen-key>"
 ```
 
 Reference:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ See a [video](https://youtu.be/zX3K-rfNZIU) for a general overview.
 
 - Python 3.13+ and `uv` installed
 - Snowflake account/role with permission to create/use the target database, schema, and pipe
-- Azure Event Hub namespace with read access (consumer group) and either `az login` or a connection string
+- Azure Event Hub namespace with read access (consumer group) and one supported auth path: local Azure CLI login, service-principal environment variables, managed identity, or an explicit per-hub connection string
 - Ability to run OpenSSL to generate RSA keys for Snowflake key-pair auth
 - Snowflake CLI `snow` (or Snowflake UI) to test key-pair auth and query Snowflake
 
@@ -137,19 +137,35 @@ of the private key to a temporary file.
 
 ### Azure authentication
 
-For Event Hub consumption, EvSnow uses `EVENTHUBNAME_{N}_CONNECTION_STRING` when it is set. Otherwise it uses the Azure CLI identity from `az login`; that identity needs `Azure Event Hubs Data Receiver` on the Event Hub or namespace.
+The pipeline uses `DefaultAzureCredential` by default, which supports local Azure CLI
+login, service-principal environment variables, and managed identity in Azure-hosted
+runtimes. Make sure you're logged in for local development:
 
 ```bash
 az login
 ```
 
-Or provide a least-privilege Listen connection string in `.env`:
+For a user-assigned managed identity, set the client ID on each Event Hub config:
 
 ```bash
-EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://<namespace>.servicebus.windows.net/;SharedAccessKeyName=EvSnowListen;SharedAccessKey=<listen-key>"
+EVENTHUBNAME_1_MANAGED_IDENTITY_CLIENT_ID="00000000-0000-0000-0000-000000000000"
 ```
 
-`AZURE_EVENTHUB_CONNECTION_STRING` is used by `tools/eventhub_sender`, not by the main pipeline receiver.
+To force Azure CLI-only auth for local testing, opt in explicitly:
+
+```bash
+EVENTHUBNAME_1_CREDENTIAL_MODE=azure_cli
+```
+
+Or provide a connection string in `.env`:
+
+```bash
+EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://...;SharedAccessKey=..."
+```
+
+Reference:
+- [DefaultAzureCredential for Python](https://learn.microsoft.com/python/api/azure-identity/azure.identity.aio.defaultazurecredential)
+- [EventHubConsumerClient options](https://learn.microsoft.com/python/api/azure-eventhub/azure.eventhub.eventhubconsumerclient)
 
 ## Use
 
@@ -208,15 +224,11 @@ EVENTHUBNAME_1_STARTING_POSITION_ON_NO_CHECKPOINT=-1
 # Skips messages already in Event Hub
 EVENTHUBNAME_1_STARTING_POSITION_ON_NO_CHECKPOINT=@latest
 
-# Option 3: Event Hub offset 0
-# This is a concrete offset, not a synonym for earliest. Prefer -1 for
-# beginning-of-stream behavior unless you intentionally want offset 0.
-EVENTHUBNAME_1_STARTING_POSITION_ON_NO_CHECKPOINT=0
 ```
 
 **How It Works:**
 
-1. **First run (no checkpoints):** Uses `STARTING_POSITION_ON_NO_CHECKPOINT` (`-1` = beginning; `@latest` = only new messages; `0` = offset zero).
+1. **First run (no checkpoints):** Uses `STARTING_POSITION_ON_NO_CHECKPOINT` (`-1` = all existing messages; `@latest` = only new messages).
 2. **Subsequent runs (checkpoints exist):** Always resumes from the last saved checkpoint; the setting is ignored.
 3. **After truncating checkpoints:** Same as first run again; uses the configured starting position.
 
@@ -227,7 +239,6 @@ EVENTHUBNAME_1_STARTING_POSITION_ON_NO_CHECKPOINT=0
 **Recommendation:** 
 - Use `-1` (default) for production to prevent message loss
 - Use `@latest` for development/testing when you only want new messages
-- Avoid `0` unless you specifically need to start from Event Hub offset zero
 
 ## Optional features
 
@@ -298,6 +309,7 @@ See [`.env.example`](./.env.example) for all available configuration options wit
 
 ## Docs
 
+- [Python Pipeline Hardening Plan](./docs/python-pipeline-hardening-plan.md) - Migration findings, milestones, and remaining hardening work
 - [Step by Step Guide](./SNOWFLAKE_COMPLETE_SETUP.md) - Setup guide for Snowflake
 - [Snowflake Quickstart](./SNOWFLAKE_QUICKSTART.md) - Compact setup and validation checklist
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Postgres control table notes:
 - When `CONTROL_TABLE_BACKEND=postgres`, `TARGET_DB`, `TARGET_SCHEMA`, and `TARGET_TABLE` are normalized to lowercase unless quoted (e.g., `"Control"` keeps case).
 - When `CONTROL_PG_AUTH_MODE=azure_token`, the app uses `DefaultAzureCredential` and passes the access token as the password; `CONTROL_PG_PASSWORD` is ignored. Ensure the Azure AD principal exists on the server and has access to the database/schema/table.
 
+Snowflake control table notes:
+- `CONTROL_OWNERSHIP_MODE=durable` is the production mode. With `CONTROL_TABLE_BACKEND=snowflake`, durable Event Hubs partition ownership requires a Snowflake Hybrid Table because standard-table primary and unique constraints are not enforced.
+- `CONTROL_OWNERSHIP_MODE=local_single_consumer_smoke` is only for a local single-consumer smoke test when Hybrid Tables are unavailable. It keeps partition ownership in memory while persisting checkpoints to a standard Snowflake table, so it does not validate multi-consumer ownership or failover.
+
 ### Snowflake authentication
 
 Generate RSA key pair for authentication:

--- a/docs/python-pipeline-hardening-plan.md
+++ b/docs/python-pipeline-hardening-plan.md
@@ -52,6 +52,7 @@ Scope:
 - Added Snowflake and Postgres ownership list/claim helpers.
 - Snowflake ownership requires a Hybrid Table with an enforced primary key for safe compare-and-set claims.
 - If an existing Snowflake ownership table is a standard table, setup fails closed with migration guidance.
+- A `CONTROL_OWNERSHIP_MODE=local_single_consumer_smoke` diagnostic path keeps ownership in memory while persisting Snowflake checkpoints to a standard table; it is only for single-consumer smoke tests when Hybrid Tables are unavailable.
 - Postgres ownership uses primary-key-backed upsert/update semantics.
 - Checkpoint backend calls are offloaded with `asyncio.to_thread(...)` behind manager-level I/O locks.
 - Checkpoint loads fail closed instead of silently starting from an unsafe position.
@@ -101,8 +102,10 @@ Gate 5 - Verification And Handoff:
 - Document that Snowflake ownership uses a Hybrid Table for enforced primary-key claims; operators without Hybrid Table support/privileges should use Postgres control tables or migrate/drop an existing standard ownership table before enabling Snowflake ownership.
 
 Latest live-smoke status:
-- Full mocked test suite passes: `405 passed`, with 2 existing warnings.
+- Full mocked test suite passes: `415 passed`, with 2 existing warnings.
 - Live Event Hub sender succeeds against `evsnowqa20260428230344.servicebus.windows.net/topic1` when using a namespace SAS connection string retrieved from Azure CLI.
 - Live pipeline with Snowflake control-table ownership fails closed before receiving messages because Snowflake Hybrid Tables are not available on the current trial account.
 - Live pipeline with Docker-backed Postgres control tables succeeds end to end: the sender wrote 5 marker messages, Event Hub receive processed them, Snowpipe Streaming flushed partition channels, and Snowflake query found 5 marker rows.
+- Live pipeline with Docker-backed Postgres control tables also passes a two-consumer load-balancing smoke: 80 unique marker rows reached Snowflake across partitions `0,1`.
+- Live Snowflake standard-table checkpoint smoke passes in single-consumer mode: `INGESTION.PUBLIC.INGESTION_STATUS_SMOKE_20260524180843` was seeded from current Event Hub offsets, phase A ingested 20 rows for marker `snowflake-control-smoke-a-20260524180843`, phase B restarted from the Snowflake checkpoints and ingested 20 rows for marker `snowflake-control-smoke-b-20260524180843`, and checkpoint rows advanced for both partitions. This validates Snowflake-backed checkpoints/resume only; partition ownership remains local and is not a durable multi-consumer ownership proof.
 - The configured Azure Postgres fallback is still not currently usable from this machine: the configured host is stale, and the discovered Azure Postgres hosts reject the configured credentials.

--- a/docs/python-pipeline-hardening-plan.md
+++ b/docs/python-pipeline-hardening-plan.md
@@ -1,0 +1,108 @@
+# Python Pipeline Hardening Plan
+
+This plan tracks the Python fixes chosen instead of a Rust migration. The gates below are intentionally scoped so each one can be implemented, peer reviewed, and verified before moving on.
+
+## Gate 1 - Snowpipe Commit Safety And Partition-Safe Routing
+
+Status: Accepted
+
+Scope:
+- Added Snowpipe Streaming SDK import compatibility for current and older `ChannelStatus` layouts.
+- Prefer `append_rows(...)` with `start_offset_token` and `end_offset_token`, with `append_row(...)` fallback.
+- Require Event Hub `sequence_number` for source-stable Snowflake offset tokens.
+- Wait for Snowflake `wait_for_commit(...)` before reporting ingest success.
+- Force channel-status validation and fail closed on row errors or fatal channel status.
+- Group orchestrator batches by Event Hub partition.
+- Route each Event Hub partition to a stable Snowflake channel suffix.
+- Fail the batch if any partition ingest fails.
+
+Verification:
+- `uv run pytest -q tests/unit/test_snowflake_client.py tests/unit/test_streaming.py tests/unit/test_orchestrator.py`
+- Result: passed during gate review.
+
+## Gate 2 - Event Hub Fail-Closed Batch Contract
+
+Status: Accepted
+
+Scope:
+- `_process_batch(...)` returns a boolean success/failure contract.
+- Sync processors run via `asyncio.to_thread(...)`.
+- Async processor functions and async callable instances are awaited.
+- Batch mutation is serialized with batch and processing locks.
+- Ready and timed-out batches are detached before processing.
+- Detached batches are tracked in an explicit FIFO queue.
+- Failed-batch restore rebuilds the current batch from detached backlog first, then newer partial batch messages.
+- Processor failure, checkpoint retry exhaustion, or missing `partition_context` fails the batch.
+- Failed batches do not checkpoint and do not advance success stats.
+- Batch failure shuts down the receive loop/client.
+- Snowflake committed replay still validates channel status before reporting success.
+
+Verification:
+- `uv run pytest -q tests/unit/test_snowflake_client.py tests/unit/test_eventhub.py tests/unit/test_orchestrator.py tests/unit/test_streaming.py`
+- Result: `168 passed`, with existing warnings under review.
+- `uv run ruff check --select F811 ...`
+- Result: passed.
+
+## Gate 3 - Durable Checkpoint Ownership And Metadata
+
+Status: Accepted
+
+Scope:
+- Replaced in-memory partition ownership with durable backend delegation.
+- Added Snowflake and Postgres ownership list/claim helpers.
+- Snowflake ownership requires a Hybrid Table with an enforced primary key for safe compare-and-set claims.
+- If an existing Snowflake ownership table is a standard table, setup fails closed with migration guidance.
+- Postgres ownership uses primary-key-backed upsert/update semantics.
+- Checkpoint backend calls are offloaded with `asyncio.to_thread(...)` behind manager-level I/O locks.
+- Checkpoint loads fail closed instead of silently starting from an unsafe position.
+- Checkpoint save failure propagates through the SDK checkpoint path.
+- Event Hub offset and sequence number are preserved separately.
+- Startup logging handles both legacy integer checkpoints and metadata-shaped checkpoints.
+- Snowflake ownership helper paths validate warehouse identifiers before issuing `USE WAREHOUSE`.
+
+Verification:
+- `uv run pytest -q tests/unit/test_snowflake_client.py tests/unit/test_eventhub.py tests/unit/test_orchestrator.py tests/unit/test_streaming.py tests/unit/test_snowflake_utils.py`
+- Result: `210 passed`, with existing warnings under review.
+- Targeted `ruff` `F401` / `F811` checks passed for changed source files.
+
+## Gate 4 - Azure Identity And SDK Options
+
+Status: Accepted
+
+Scope:
+- Aligned code and docs around production identity behavior.
+- Prefer `DefaultAzureCredential` for production-capable authentication.
+- Keep `AzureCliCredential` as an explicit local-development opt-in.
+- Added user-assigned managed identity client ID support.
+- Close credentials on token validation failure and shutdown.
+- Pass configured Event Hubs retry and load-balancing options into `EventHubConsumerClient`.
+- Pass configured prefetch, max-wait, last-enqueued tracking, and error callback options into `receive(...)`.
+- Preserve fail-closed behavior when the SDK calls `on_error`, even if the SDK swallows callback exceptions.
+- Fail closed on receive-time credential errors instead of leaving the consumer running.
+- Validate partition ownership expiration against the load-balancing interval.
+- Allow Azure's documented `max_wait_time=0` receive mode.
+- Reject unsafe fresh-start `starting_position=0`; use `-1` for beginning or `@latest` for new events.
+- Updated README and `.env.example` for identity mode, SDK options, and connection-string override behavior.
+
+Verification:
+- `uv run pytest -q tests/unit`
+- Result: `392 passed`, with 2 existing warnings under review.
+- `uv run ruff check`
+- Result: passed.
+- `uv run python -m py_compile src/utils/azure_identity.py src/utils/config_models/eventhub.py src/utils/config.py src/consumers/eventhub.py src/main.py`
+- Result: passed.
+
+## Open Gates
+
+Gate 5 - Verification And Handoff:
+- Run a live two-consumer Snowflake/Event Hub ownership and load-balancing smoke test if credentials and test infrastructure are available.
+- Update operator docs for identity, ownership, checkpoint behavior, and remaining warnings.
+- Verify that code comments explain the chosen safety/SDK decisions and include vendor documentation links where those decisions depend on external SDK behavior.
+- Document that Snowflake ownership uses a Hybrid Table for enforced primary-key claims; operators without Hybrid Table support/privileges should use Postgres control tables or migrate/drop an existing standard ownership table before enabling Snowflake ownership.
+
+Latest live-smoke status:
+- Full mocked test suite passes: `405 passed`, with 2 existing warnings.
+- Live Event Hub sender succeeds against `evsnowqa20260428230344.servicebus.windows.net/topic1` when using a namespace SAS connection string retrieved from Azure CLI.
+- Live pipeline with Snowflake control-table ownership fails closed before receiving messages because Snowflake Hybrid Tables are not available on the current trial account.
+- Live pipeline with Docker-backed Postgres control tables succeeds end to end: the sender wrote 5 marker messages, Event Hub receive processed them, Snowpipe Streaming flushed partition channels, and Snowflake query found 5 marker rows.
+- The configured Azure Postgres fallback is still not currently usable from this machine: the configured host is stale, and the discovered Azure Postgres hosts reject the configured credentials.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evsnow"
-version = "0.1.1"
+version = "0.1.2"
 description = "EvSnow - Azure EventHub to Snowflake streaming pipeline"
 readme = "README.md"
 authors = [

--- a/src/consumers/checkpoints.py
+++ b/src/consumers/checkpoints.py
@@ -5,8 +5,8 @@ Provides a CheckpointStore compatible with Azure EventHub SDK backed by
 Snowflake or Postgres control tables.
 """
 
+import asyncio
 import logging
-import time
 from collections.abc import Iterable
 from typing import Any, Protocol
 
@@ -16,6 +16,7 @@ from azure.eventhub.aio import CheckpointStore
 from utils.config import PostgresConnectionConfig, SnowflakeConnectionConfig
 
 logger = logging.getLogger(__name__)
+CheckpointValue = int | dict[str, Any]
 
 __all__ = [
     "DatabaseCheckpointStore",
@@ -29,13 +30,25 @@ __all__ = [
 class CheckpointManagerProtocol(Protocol):
     """Protocol for checkpoint managers used by the Azure SDK store."""
 
-    async def get_last_checkpoint(self) -> dict[str, int] | None: ...
+    async def get_last_checkpoint(self) -> dict[str, CheckpointValue] | None: ...
 
     async def save_checkpoint(
         self,
         partition_checkpoints: dict[str, int],
         partition_metadata: dict[str, dict[str, Any]] | None = None,
     ) -> bool: ...
+
+    async def list_ownership(
+        self,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+    ) -> list[dict[str, Any]]: ...
+
+    async def claim_ownership(
+        self,
+        ownership_list: Iterable[dict[str, Any]],
+    ) -> list[dict[str, Any]]: ...
 
     def close(self) -> None: ...
 
@@ -67,13 +80,19 @@ class SnowflakeCheckpointManager:
         self.snowflake_config = snowflake_config
         self.session = session
         self._external_session = session is not None
+        self._io_lock = asyncio.Lock()
 
-    async def get_last_checkpoint(self) -> dict[str, int] | None:
+    async def _run_backend(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        async with self._io_lock:
+            return await asyncio.to_thread(func, *args, **kwargs)
+
+    async def get_last_checkpoint(self) -> dict[str, CheckpointValue] | None:
         """Get last checkpoint per partition from Snowflake."""
         try:
             from utils.snowflake import get_partition_checkpoints
 
-            result: dict[str, int] | None = get_partition_checkpoints(
+            result: dict[str, CheckpointValue] | None = await self._run_backend(
+                get_partition_checkpoints,
                 eventhub_namespace=self.eventhub_namespace,
                 eventhub=self.eventhub_name,
                 target_db=self.target_db,
@@ -94,7 +113,7 @@ class SnowflakeCheckpointManager:
 
         except Exception as e:
             logger.error("Failed to get last checkpoint: %s", e, exc_info=True)
-            return None
+            raise
 
     async def save_checkpoint(
         self,
@@ -129,7 +148,8 @@ class SnowflakeCheckpointManager:
                         self.control_table,
                     )
 
-                    insert_partition_checkpoint(
+                    await self._run_backend(
+                        insert_partition_checkpoint,
                         eventhub_namespace=self.eventhub_namespace,
                         eventhub=self.eventhub_name,
                         target_db=self.target_db,
@@ -174,6 +194,46 @@ class SnowflakeCheckpointManager:
                 )
                 return False
 
+    async def list_ownership(
+        self,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+    ) -> list[dict[str, Any]]:
+        from utils.snowflake import list_partition_ownership
+
+        return await self._run_backend(
+            list_partition_ownership,
+            fully_qualified_namespace=fully_qualified_namespace,
+            eventhub_name=eventhub_name,
+            consumer_group=consumer_group,
+            target_db=self.target_db,
+            target_schema=self.target_schema,
+            target_table=self.target_table,
+            config=self.snowflake_config,
+            control_db=self.control_db,
+            control_schema=self.control_schema,
+            control_table=self.control_table,
+        )
+
+    async def claim_ownership(
+        self,
+        ownership_list: Iterable[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        from utils.snowflake import claim_partition_ownership
+
+        return await self._run_backend(
+            claim_partition_ownership,
+            ownership_list=list(ownership_list),
+            target_db=self.target_db,
+            target_schema=self.target_schema,
+            target_table=self.target_table,
+            config=self.snowflake_config,
+            control_db=self.control_db,
+            control_schema=self.control_schema,
+            control_table=self.control_table,
+        )
+
     def close(self):
         """Close owned Snowflake session resources."""
         if self.session and not self._external_session:
@@ -204,13 +264,19 @@ class PostgresCheckpointManager:
         self.control_schema = control_schema
         self.control_table = control_table
         self.postgres_config = postgres_config
+        self._io_lock = asyncio.Lock()
 
-    async def get_last_checkpoint(self) -> dict[str, int] | None:
+    async def _run_backend(self, func: Any, *args: Any, **kwargs: Any) -> Any:
+        async with self._io_lock:
+            return await asyncio.to_thread(func, *args, **kwargs)
+
+    async def get_last_checkpoint(self) -> dict[str, CheckpointValue] | None:
         """Get last checkpoint per partition from Postgres."""
         try:
             from utils.postgres import get_partition_checkpoints
 
-            result: dict[str, int] | None = get_partition_checkpoints(
+            result: dict[str, CheckpointValue] | None = await self._run_backend(
+                get_partition_checkpoints,
                 eventhub_namespace=self.eventhub_namespace,
                 eventhub=self.eventhub_name,
                 target_db=self.target_db,
@@ -266,7 +332,8 @@ class PostgresCheckpointManager:
                         self.control_table,
                     )
 
-                    insert_partition_checkpoint(
+                    await self._run_backend(
+                        insert_partition_checkpoint,
                         eventhub_namespace=self.eventhub_namespace,
                         eventhub=self.eventhub_name,
                         target_db=self.target_db,
@@ -311,6 +378,46 @@ class PostgresCheckpointManager:
                 )
                 raise
 
+    async def list_ownership(
+        self,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+    ) -> list[dict[str, Any]]:
+        from utils.postgres import list_partition_ownership
+
+        return await self._run_backend(
+            list_partition_ownership,
+            fully_qualified_namespace=fully_qualified_namespace,
+            eventhub_name=eventhub_name,
+            consumer_group=consumer_group,
+            target_db=self.target_db,
+            target_schema=self.target_schema,
+            target_table=self.target_table,
+            config=self.postgres_config,
+            control_db=self.control_db,
+            control_schema=self.control_schema,
+            control_table=self.control_table,
+        )
+
+    async def claim_ownership(
+        self,
+        ownership_list: Iterable[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        from utils.postgres import claim_partition_ownership
+
+        return await self._run_backend(
+            claim_partition_ownership,
+            ownership_list=list(ownership_list),
+            target_db=self.target_db,
+            target_schema=self.target_schema,
+            target_table=self.target_table,
+            config=self.postgres_config,
+            control_db=self.control_db,
+            control_schema=self.control_schema,
+            control_table=self.control_table,
+        )
+
     def close(self):
         """Close cached Postgres connections."""
         try:
@@ -327,7 +434,6 @@ class DatabaseCheckpointStore(CheckpointStore):
     def __init__(self, checkpoint_manager: CheckpointManagerProtocol, backend_label: str):
         self.checkpoint_manager = checkpoint_manager
         self.backend_label = backend_label
-        self._ownership_cache: dict[str, dict[str, Any]] = {}
         self._checkpoint_cache: dict[str, dict[str, Any]] = {}
 
     async def list_ownership(
@@ -337,27 +443,18 @@ class DatabaseCheckpointStore(CheckpointStore):
         consumer_group: str,
         **kwargs: Any,
     ) -> list[dict[str, Any]]:
-        """Return cached ownership records."""
-        return list(self._ownership_cache.values())
+        """Return durable ownership records from the configured backend."""
+        return await self.checkpoint_manager.list_ownership(
+            fully_qualified_namespace,
+            eventhub_name,
+            consumer_group,
+        )
 
     async def claim_ownership(
         self, ownership_list: Iterable[dict[str, Any]], **kwargs: Any
     ) -> list[dict[str, Any]]:
-        """Claim ownership for partitions and cache the claims."""
-        claimed = []
-        for ownership in ownership_list:
-            partition_id = ownership["partition_id"]
-            self._ownership_cache[partition_id] = {
-                "fully_qualified_namespace": ownership["fully_qualified_namespace"],
-                "eventhub_name": ownership["eventhub_name"],
-                "consumer_group": ownership["consumer_group"],
-                "partition_id": partition_id,
-                "owner_id": ownership["owner_id"],
-                "last_modified_time": time.time(),
-                "etag": str(time.time()),
-            }
-            claimed.append(self._ownership_cache[partition_id])
-
+        """Claim partition ownership through durable backend compare-and-set."""
+        claimed = await self.checkpoint_manager.claim_ownership(ownership_list)
         logger.debug("Claimed ownership for %s partitions", len(claimed))
         return claimed
 
@@ -376,25 +473,11 @@ class DatabaseCheckpointStore(CheckpointStore):
 
         self._checkpoint_cache[partition_id] = checkpoint
 
-        try:
-            offset_int = int(offset)
-            logger.info(
-                "✅ Converted offset to int: partition=%s, offset_int=%s", partition_id, offset_int
-            )
-        except (ValueError, TypeError) as e:
-            logger.error(
-                "❌ Invalid offset format: offset=%r, type=%s, error=%s, falling back to sequence_number",
-                offset,
-                type(offset).__name__,
-                e,
-            )
-            offset_int = sequence_number
-
-        partition_checkpoints = {partition_id: offset_int}
+        partition_checkpoints = {partition_id: sequence_number}
         partition_metadata = {
             partition_id: {
                 "sequence_number": sequence_number,
-                "offset_string": offset,
+                "offset_string": str(offset),
                 "fully_qualified_namespace": checkpoint.get("fully_qualified_namespace"),
                 "eventhub_name": checkpoint.get("eventhub_name"),
                 "consumer_group": checkpoint.get("consumer_group"),
@@ -404,7 +487,7 @@ class DatabaseCheckpointStore(CheckpointStore):
         logger.info(
             "💾 Calling save_checkpoint: partition=%s, waterlevel=%s, metadata.sequence_number=%s",
             partition_id,
-            offset_int,
+            sequence_number,
             sequence_number,
         )
 
@@ -420,7 +503,7 @@ class DatabaseCheckpointStore(CheckpointStore):
                 sequence_number,
             )
         else:
-            logger.warning("Failed to update checkpoint for partition %s", partition_id)
+            raise RuntimeError(f"Failed to update checkpoint for partition {partition_id}")
 
     async def list_checkpoints(
         self,
@@ -436,14 +519,23 @@ class DatabaseCheckpointStore(CheckpointStore):
             return []
 
         checkpoints = []
-        for partition_id, offset_value in checkpoints_data.items():
+        for partition_id, checkpoint_value in checkpoints_data.items():
+            if isinstance(checkpoint_value, dict):
+                offset_value = checkpoint_value.get("offset") or checkpoint_value.get(
+                    "offset_string"
+                )
+                sequence_number = checkpoint_value.get("sequence_number")
+            else:
+                offset_value = checkpoint_value
+                sequence_number = checkpoint_value
+
             checkpoint = {
                 "fully_qualified_namespace": fully_qualified_namespace,
                 "eventhub_name": eventhub_name,
                 "consumer_group": consumer_group,
                 "partition_id": partition_id,
                 "offset": str(offset_value),
-                "sequence_number": offset_value,
+                "sequence_number": int(sequence_number),
             }
             self._checkpoint_cache[partition_id] = checkpoint
             checkpoints.append(checkpoint)

--- a/src/consumers/checkpoints.py
+++ b/src/consumers/checkpoints.py
@@ -531,6 +531,8 @@ class DatabaseCheckpointStore(CheckpointStore):
             else:
                 offset_value = checkpoint_value
                 sequence_number = checkpoint_value
+            if sequence_number is None:
+                sequence_number = offset_value if offset_value is not None else 0
 
             checkpoint = {
                 "fully_qualified_namespace": fully_qualified_namespace,

--- a/src/consumers/checkpoints.py
+++ b/src/consumers/checkpoints.py
@@ -7,6 +7,8 @@ Snowflake or Postgres control tables.
 
 import asyncio
 import logging
+import time
+import uuid
 from collections.abc import Iterable
 from typing import Any, Protocol
 
@@ -22,6 +24,7 @@ __all__ = [
     "DatabaseCheckpointStore",
     "PostgresCheckpointManager",
     "PostgresCheckpointStore",
+    "SingleConsumerSnowflakeCheckpointStore",
     "SnowflakeCheckpointManager",
     "SnowflakeCheckpointStore",
 ]
@@ -554,6 +557,75 @@ class SnowflakeCheckpointStore(DatabaseCheckpointStore):
 
     def __init__(self, checkpoint_manager: SnowflakeCheckpointManager):
         super().__init__(checkpoint_manager, backend_label="Snowflake")
+
+
+class SingleConsumerSnowflakeCheckpointStore(DatabaseCheckpointStore):
+    """Snowflake checkpoint store with local ownership for diagnostic smoke tests.
+
+    Azure's Event Hubs SDK uses the checkpoint store for both partition ownership
+    and checkpoints. Snowflake standard tables can persist checkpoint MERGEs, but
+    they cannot enforce the compare-and-set ownership contract because standard
+    PRIMARY KEY / UNIQUE constraints are not enforced. This store keeps ownership
+    in memory for a single process while still persisting checkpoints to Snowflake.
+    Do not use it for multiple consumers in the same consumer group.
+    https://docs.snowflake.com/en/sql-reference/constraints-overview
+    """
+
+    def __init__(self, checkpoint_manager: SnowflakeCheckpointManager):
+        super().__init__(checkpoint_manager, backend_label="Snowflake")
+        self._ownership: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+        self._ownership_lock = asyncio.Lock()
+
+    async def list_ownership(
+        self,
+        fully_qualified_namespace: str,
+        eventhub_name: str,
+        consumer_group: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        async with self._ownership_lock:
+            return [
+                ownership.copy()
+                for (
+                    namespace,
+                    hub_name,
+                    group_name,
+                    _partition_id,
+                ), ownership in self._ownership.items()
+                if (
+                    namespace == fully_qualified_namespace
+                    and hub_name == eventhub_name
+                    and group_name == consumer_group
+                )
+            ]
+
+    async def claim_ownership(
+        self, ownership_list: Iterable[dict[str, Any]], **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        async with self._ownership_lock:
+            claimed: list[dict[str, Any]] = []
+            for ownership in ownership_list:
+                key = (
+                    ownership["fully_qualified_namespace"],
+                    ownership["eventhub_name"],
+                    ownership["consumer_group"],
+                    ownership["partition_id"],
+                )
+                current = self._ownership.get(key)
+                requested_etag = ownership.get("etag")
+                if current is not None and requested_etag != current.get("etag"):
+                    continue
+
+                updated = {
+                    **ownership,
+                    "etag": uuid.uuid4().hex,
+                    "last_modified_time": time.time(),
+                }
+                self._ownership[key] = updated
+                claimed.append(updated.copy())
+
+        logger.debug("Locally claimed ownership for %s partitions", len(claimed))
+        return claimed
 
 
 class PostgresCheckpointStore(DatabaseCheckpointStore):

--- a/src/consumers/eventhub.py
+++ b/src/consumers/eventhub.py
@@ -905,7 +905,9 @@ class EventHubAsyncConsumer:
                             f"✅ {message_count} remaining messages processed and checkpoints updated"
                         )
                     else:
-                        logger.error("❌ Remaining batch failed during shutdown; leaving it uncheckpointed")
+                        logger.error(
+                            "❌ Remaining batch failed during shutdown; leaving it uncheckpointed"
+                        )
                 except Exception as e:
                     logger.error(f"❌ Error processing remaining batch: {e}", exc_info=True)
             else:
@@ -1108,7 +1110,9 @@ class EventHubAsyncConsumer:
         return int(checkpoint_value)
 
     async def _run_message_processor(self, messages: list[EventHubMessage]) -> bool:
-        processor_call = self.message_processor.__call__ if callable(self.message_processor) else None
+        processor_call = (
+            self.message_processor.__call__ if callable(self.message_processor) else None
+        )
         async_call = inspect.iscoroutinefunction(
             self.message_processor
         ) or inspect.iscoroutinefunction(processor_call)
@@ -1376,17 +1380,13 @@ class EventHubAsyncConsumer:
                     return True
                 else:
                     logger.error("❌ Message processor returned failure")
-                    logfire.error(
-                        "Message processor returned failure", batch_size=len(messages)
-                    )
+                    logfire.error("Message processor returned failure", batch_size=len(messages))
                     span.set_attribute("processor_failure", True)
                     return False
 
             except Exception as e:
                 logger.error(f"❌ Error processing batch: {e}", exc_info=True)
-                logfire.error(
-                    "Batch processing error", error=str(e), batch_size=len(messages)
-                )
+                logfire.error("Batch processing error", error=str(e), batch_size=len(messages))
                 span.set_attribute("error", str(e))
                 return False
 

--- a/src/consumers/eventhub.py
+++ b/src/consumers/eventhub.py
@@ -12,6 +12,7 @@ Based on Azure EventHub SDK patterns but adapted for database checkpointing.
 """
 
 import asyncio
+import inspect
 import json
 import logging
 import time
@@ -33,7 +34,7 @@ from consumers.checkpoints import (
     SnowflakeCheckpointStore,
 )
 from consumers.messages import BytesEncoder, EventHubMessage, MessageBatch, _convert_bytes_to_str
-from utils.azure_identity import build_eventhub_cli_credential
+from utils.azure_identity import build_eventhub_credential
 from utils.config import EventHubConfig, PostgresConnectionConfig, SnowflakeConnectionConfig
 
 logger = logging.getLogger(__name__)
@@ -128,6 +129,12 @@ class EventHubAsyncConsumer:
         self.tasks: set[asyncio.Task] = set()
         self._first_message_logged: set[str] = set()  # Track first message per partition
         self._batch_counter = 0
+        self._batch_lock = asyncio.Lock()
+        self._processing_lock = asyncio.Lock()
+        self._detached_batches: list[MessageBatch] = []
+        self._restored_detached_batch_ids: set[str] = set()
+        self._receive_error: Exception | None = None
+        self._receive_error_close_task: asyncio.Task[None] | None = None
 
         # Statistics
         self.stats: dict[str, Any] = {
@@ -339,10 +346,6 @@ class EventHubAsyncConsumer:
             logger.info(
                 f"   Starting from LATEST (starting_position='{starting_pos}') - only NEW messages after connection will be received."
             )
-        elif starting_pos == "0":
-            logger.info(
-                f"   Starting from Event Hub offset 0 (starting_position='{starting_pos}') - use -1 for beginning-of-stream semantics."
-            )
 
         logger.info(
             "   This ensures consistent behavior when starting fresh. Change with EVENTHUBNAME_{N}_STARTING_POSITION_ON_NO_CHECKPOINT."
@@ -418,6 +421,80 @@ class EventHubAsyncConsumer:
             eventhub=self.eventhub_config.name,
         )
 
+    def _eventhub_client_options(self, checkpoint_store: Any) -> dict[str, Any]:
+        """Build Azure Event Hubs client options from validated config.
+
+        The Azure SDK documents retry and load-balancing options on the
+        EventHubConsumerClient constructor/from_connection_string API, not on
+        receive(). Keeping that split here prevents operator config from being
+        silently ignored. Reference:
+        https://learn.microsoft.com/python/api/azure-eventhub/azure.eventhub.eventhubconsumerclient
+        """
+        options: dict[str, Any] = {
+            "checkpoint_store": checkpoint_store,
+            "retry_total": self.eventhub_config.retry_total,
+            "retry_backoff_factor": self.eventhub_config.retry_backoff_factor,
+            "retry_backoff_max": self.eventhub_config.retry_backoff_max,
+            "retry_mode": self.eventhub_config.retry_mode,
+            "load_balancing_interval": self.eventhub_config.load_balancing_interval,
+            "load_balancing_strategy": self.eventhub_config.load_balancing_strategy,
+        }
+        if self.eventhub_config.partition_ownership_expiration_interval is not None:
+            options["partition_ownership_expiration_interval"] = (
+                self.eventhub_config.partition_ownership_expiration_interval
+            )
+        return options
+
+    def _eventhub_receive_options(self) -> dict[str, Any]:
+        """Build receive-loop options from validated config."""
+        return {
+            "max_wait_time": self.eventhub_config.max_wait_time,
+            "prefetch": self.eventhub_config.prefetch_count,
+            "track_last_enqueued_event_properties": (
+                self.eventhub_config.track_last_enqueued_event_properties
+            ),
+            "on_error": self._on_receive_error,
+        }
+
+    async def _on_receive_error(
+        self,
+        partition_context: PartitionContext | None,
+        error: Exception,
+    ) -> None:
+        """Fail closed when the SDK reports a partition receive error."""
+        partition_id = getattr(partition_context, "partition_id", "<unknown>")
+        logger.error(
+            "❌ Event Hub receive callback failed for partition %s: %s",
+            partition_id,
+            error,
+            exc_info=True,
+        )
+        self._receive_error = error
+        self.running = False
+        if self.client is not None:
+            # The Azure SDK may log and swallow exceptions raised by on_error,
+            # so closing the client is the deterministic stop signal. We trigger
+            # close out-of-band instead of awaiting it inside the callback because
+            # EventHubConsumerClient.close() can cancel the active receive task that
+            # is currently executing this callback.
+            # https://learn.microsoft.com/python/api/azure-eventhub/azure.eventhub.eventhubconsumerclient
+            self._receive_error_close_task = asyncio.create_task(
+                self._close_client_after_receive_error()
+            )
+        return None
+
+    async def _close_client_after_receive_error(self) -> None:
+        client = self.client
+        if client is None:
+            return
+        try:
+            await client.close()
+        except asyncio.CancelledError:
+            logger.debug("EventHub client close task cancelled after receive error")
+            raise
+        except Exception as close_error:
+            logger.warning("Error closing EventHub client after receive error: %s", close_error)
+
     def _raise_rbac_permission_error(
         self,
         *,
@@ -456,8 +533,9 @@ class EventHubAsyncConsumer:
             True if the error was handled (and should not be re-raised).
             False if the caller should re-raise the original exception.
 
-        Note: This preserves the current behavior, including swallowing certain
-        credential-chain errors after printing guidance.
+        Credential-chain errors are logged with actionable guidance and then
+        re-raised by the caller so startup/receive failures do not leave the
+        consumer running with open resources.
         """
 
         error_msg = str(receive_error).lower()
@@ -479,7 +557,7 @@ class EventHubAsyncConsumer:
                 error_type=error_type,
                 receive_error=receive_error,
             )
-            return True
+            return False
 
         if (
             any(
@@ -592,7 +670,8 @@ class EventHubAsyncConsumer:
                 logger.info(
                     "   SDK will automatically resume from NEXT sequence after these checkpoints:"
                 )
-                for partition_id, seq_num in partition_checkpoints.items():
+                for partition_id, checkpoint_value in partition_checkpoints.items():
+                    seq_num = self._checkpoint_sequence_number(checkpoint_value)
                     logger.info(
                         f"      Partition {partition_id}: last processed seq={seq_num}, will resume from seq={seq_num + 1}"
                     )
@@ -607,6 +686,7 @@ class EventHubAsyncConsumer:
             logger.info("🔌 Creating EventHub client with checkpoint store...")
 
             logger.info("🔗 Creating EventHub client...")
+            client_options = self._eventhub_client_options(checkpoint_store)
 
             # Use connection string if configured, otherwise use credential
             if self.eventhub_config.connection_string:
@@ -615,33 +695,44 @@ class EventHubAsyncConsumer:
                     conn_str=self.eventhub_config.connection_string,
                     consumer_group=self.eventhub_config.consumer_group,
                     eventhub_name=self.eventhub_config.name,
-                    checkpoint_store=checkpoint_store,
+                    **client_options,
                 )
                 logger.info("✅ EventHub client created with connection string")
             else:
-                logger.info("🔐 Initializing Azure CLI credential (Event Hub scope)...")
+                logger.info(
+                    "🔐 Initializing %s credential (Event Hub scope)...",
+                    self.eventhub_config.credential_mode,
+                )
                 try:
-                    credential, expiry = await build_eventhub_cli_credential(
+                    credential, expiry, credential_label = await build_eventhub_credential(
                         namespace=self.eventhub_config.namespace,
                         logger=logger,
+                        credential_mode=self.eventhub_config.credential_mode,
+                        managed_identity_client_id=(
+                            self.eventhub_config.managed_identity_client_id
+                        ),
                     )
                     self.credential = credential
                     logfire.info(
                         "Azure credential test successful",
                         token_expiry=expiry,
                         namespace=self.eventhub_config.namespace,
+                        credential=credential_label,
                     )
                 except Exception as cred_error:
-                    logger.error(f"❌ Failed to create or test AzureCliCredential: {cred_error}")
+                    logger.error(f"❌ Failed to create or test Azure credential: {cred_error}")
                     logger.error("")
                     logger.error("🔧 TROUBLESHOOTING - Azure Authentication:")
                     logger.error("")
                     logger.error("For LOCAL DEVELOPMENT:")
-                    logger.error("  Option 1: Use Azure CLI (Recommended)")
+                    logger.error("  Option 1: Use DefaultAzureCredential with Azure CLI login")
                     logger.error("    1. Run: az login")
                     logger.error("    2. Run: az account show")
                     logger.error(
                         "    3. Ensure your account has 'Azure Event Hubs Data Receiver' role"
+                    )
+                    logger.error(
+                        "    4. For CLI-only local auth, set EVENTHUBNAME_{N}_CREDENTIAL_MODE=azure_cli"
                     )
                     logger.error("")
                     logger.error("  Option 2: Use Connection String (Quick Testing)")
@@ -662,7 +753,7 @@ class EventHubAsyncConsumer:
                     )
                     logger.error("")
                     logfire.error(
-                        "AzureCliCredential creation failed",
+                        "Azure credential creation failed",
                         error=str(cred_error),
                         namespace=self.eventhub_config.namespace,
                     )
@@ -679,7 +770,7 @@ class EventHubAsyncConsumer:
                     eventhub_name=self.eventhub_config.name,
                     credential=self.credential,
                     consumer_group=self.eventhub_config.consumer_group,
-                    checkpoint_store=checkpoint_store,
+                    **client_options,
                 )
                 logger.info("✅ EventHub client created with credential-based auth")
 
@@ -716,8 +807,10 @@ class EventHubAsyncConsumer:
 
             try:
                 # Determine starting position based on checkpoint existence
+                self._receive_error = None
                 receive_kwargs: dict[str, Any] = {
                     "on_event": self._on_event,
+                    **self._eventhub_receive_options(),
                 }
 
                 # Only set starting_position if NO checkpoints exist
@@ -733,6 +826,8 @@ class EventHubAsyncConsumer:
                     )
 
                 await self.client.receive(**receive_kwargs)
+                if self._receive_error is not None:
+                    raise self._receive_error
             except Exception as receive_error:
                 handled = self._handle_receive_error(receive_error)
                 if not handled:
@@ -780,10 +875,17 @@ class EventHubAsyncConsumer:
                 try:
                     if not self.current_batch.ready_reason:
                         self.current_batch.ready_reason = "shutdown"
-                    await self._process_batch(self.current_batch)
-                    logger.info(
-                        f"✅ {message_count} remaining messages processed and checkpoints updated"
+                    batch_to_process = self.current_batch
+                    success = await self._process_detached_batch(
+                        batch_to_process,
+                        allow_when_stopped=True,
                     )
+                    if success:
+                        logger.info(
+                            f"✅ {message_count} remaining messages processed and checkpoints updated"
+                        )
+                    else:
+                        logger.error("❌ Remaining batch failed during shutdown; leaving it uncheckpointed")
                 except Exception as e:
                     logger.error(f"❌ Error processing remaining batch: {e}", exc_info=True)
             else:
@@ -894,14 +996,19 @@ class EventHubAsyncConsumer:
                 f"Current batch size: {len(self.current_batch.messages) if self.current_batch else 0}"
             )
 
-            # Add to current batch
-            if self.current_batch and self.current_batch.add_message(message):
-                # Batch is ready - process it
+            batch_to_process: MessageBatch | None = None
+            async with self._batch_lock:
+                if self.current_batch and self.current_batch.add_message(message):
+                    batch_to_process = self.current_batch
+                    self._detached_batches.append(batch_to_process)
+                    self._restored_detached_batch_ids.discard(batch_to_process.batch_id)
+                    self.current_batch = self._new_batch(reason="after_process")
+
+            if batch_to_process:
                 logger.info(
-                    f"🔄 Batch ready for processing ({len(self.current_batch.messages)} messages)"
+                    f"🔄 Batch ready for processing ({len(batch_to_process.messages)} messages)"
                 )
-                await self._process_batch(self.current_batch)
-                self.current_batch = self._new_batch(reason="after_process")
+                await self._process_detached_batch(batch_to_process)
 
         except Exception as e:
             logger.error(f"Error processing event: {e}", exc_info=True)
@@ -927,18 +1034,25 @@ class EventHubAsyncConsumer:
                         f"age: {time.time() - self.current_batch.created_at if self.current_batch else 0:.1f}s"
                     )
 
-                if (
-                    self.current_batch
-                    and self.current_batch.messages
-                    and self.current_batch.is_ready()
-                ):
+                batch_to_process = None
+                async with self._batch_lock:
+                    if (
+                        self.current_batch
+                        and self.current_batch.messages
+                        and self.current_batch.is_ready()
+                    ):
+                        batch_to_process = self.current_batch
+                        batch_to_process.mark_timeout_ready()
+                        self._detached_batches.append(batch_to_process)
+                        self._restored_detached_batch_ids.discard(batch_to_process.batch_id)
+                        self.current_batch = self._new_batch(reason="timeout_reset")
+
+                if batch_to_process:
                     # Process timed-out batch
                     logger.info(
-                        f"⏱️ Batch timeout reached! Processing {len(self.current_batch.messages)} messages"
+                        f"⏱️ Batch timeout reached! Processing {len(batch_to_process.messages)} messages"
                     )
-                    self.current_batch.mark_timeout_ready()
-                    await self._process_batch(self.current_batch)
-                    self.current_batch = self._new_batch(reason="timeout_reset")
+                    await self._process_detached_batch(batch_to_process)
 
             except asyncio.CancelledError:
                 logger.info("⏰ Batch timeout handler cancelled")
@@ -963,31 +1077,125 @@ class EventHubAsyncConsumer:
         )
         return batch
 
-    async def _process_batch(self, batch: MessageBatch) -> None:
+    @staticmethod
+    def _checkpoint_sequence_number(checkpoint_value: Any) -> int:
+        if isinstance(checkpoint_value, dict):
+            return int(checkpoint_value["sequence_number"])
+        return int(checkpoint_value)
+
+    async def _run_message_processor(self, messages: list[EventHubMessage]) -> bool:
+        processor_call = self.message_processor.__call__ if callable(self.message_processor) else None
+        async_call = inspect.iscoroutinefunction(
+            self.message_processor
+        ) or inspect.iscoroutinefunction(processor_call)
+        if async_call:
+            result = self.message_processor(messages)
+        else:
+            result = await asyncio.to_thread(self.message_processor, messages)
+        if inspect.isawaitable(result):
+            result = await result
+        return bool(result)
+
+    async def _restore_failed_batch(self, failed_batch: MessageBatch) -> None:
+        async with self._batch_lock:
+            if failed_batch.batch_id in self._restored_detached_batch_ids:
+                return
+
+            current_batch = self.current_batch
+            ordered_batches = list(self._detached_batches)
+            if failed_batch not in ordered_batches:
+                ordered_batches.append(failed_batch)
+
+            restored_batch = ordered_batches[0]
+            for queued_batch in ordered_batches[1:]:
+                if queued_batch is restored_batch:
+                    continue
+                for message in queued_batch.messages:
+                    restored_batch.add_message(message)
+
+            if current_batch and current_batch not in ordered_batches and current_batch.messages:
+                for message in current_batch.messages:
+                    restored_batch.add_message(message)
+
+            self.current_batch = restored_batch
+            self._restored_detached_batch_ids.update(batch.batch_id for batch in ordered_batches)
+            self._detached_batches.clear()
+
+    async def _remove_detached_batch(self, batch: MessageBatch) -> None:
+        async with self._batch_lock:
+            self._detached_batches = [
+                detached_batch
+                for detached_batch in self._detached_batches
+                if detached_batch is not batch
+            ]
+            self._restored_detached_batch_ids.discard(batch.batch_id)
+
+            if self.current_batch is batch:
+                self._restored_detached_batch_ids.discard(batch.batch_id)
+            else:
+                self._restored_detached_batch_ids.clear()
+
+    async def _stop_after_batch_failure(self) -> None:
+        self.running = False
+        if not self.client:
+            return
+
+        try:
+            await self.client.close()
+        except Exception as exc:
+            logger.warning("Error closing EventHub client after batch failure: %s", exc)
+        finally:
+            self.client = None
+
+    async def _process_detached_batch(
+        self,
+        batch: MessageBatch,
+        *,
+        allow_when_stopped: bool = False,
+    ) -> bool:
+        async with self._processing_lock:
+            if not self.running and not allow_when_stopped:
+                await self._restore_failed_batch(batch)
+                return False
+
+            success = await self._process_batch(batch)
+
+            if success:
+                await self._remove_detached_batch(batch)
+                return True
+
+            await self._restore_failed_batch(batch)
+            if not allow_when_stopped:
+                logger.error("❌ Batch failed; leaving batch intact and stopping consumer")
+                await self._stop_after_batch_failure()
+            return False
+
+    async def _process_batch(self, batch: MessageBatch) -> bool:
         """Process a batch of messages."""
+        messages = list(batch.messages)
         batch_age_seconds = time.time() - batch.created_at
         with logfire.span(
             "eventhub.batch",
             batch_id=batch.batch_id,
             ready_reason=batch.ready_reason or "unknown",
-            batch_size=len(batch.messages),
+            batch_size=len(messages),
             partitions=list(batch.last_sequence_by_partition.keys()),
             eventhub_name=self.eventhub_config.name,
             batch_age_seconds=batch_age_seconds,
         ) as span:
-            if not batch.messages:
+            if not messages:
                 logger.debug("No messages in batch to process")
                 span.set_attribute("empty_batch", True)
-                return
+                return True
 
-            logger.info(f"🔄 Processing batch of {len(batch.messages)} messages")
+            logger.info(f"🔄 Processing batch of {len(messages)} messages")
             logger.info(f"   Partitions in batch: {list(batch.last_sequence_by_partition.keys())}")
             logger.info(f"   Sequence ranges: {batch.last_sequence_by_partition}")
 
             try:
                 # Call the message processor
                 logger.info("📤 Calling message processor...")
-                success = self.message_processor(batch.messages)
+                success = await self._run_message_processor(messages)
 
                 span.set_attribute("processor_success", success)
 
@@ -998,7 +1206,7 @@ class EventHubAsyncConsumer:
                     # This tells EventHub where we've successfully processed up to
                     # Group messages by partition to get the last message per partition
                     last_message_by_partition: dict[str, EventHubMessage] = {}
-                    for message in batch.messages:
+                    for message in messages:
                         partition_id = message.partition_id
                         if (
                             partition_id not in last_message_by_partition
@@ -1014,40 +1222,51 @@ class EventHubAsyncConsumer:
                     checkpoints_updated = 0
                     max_checkpoint_attempts = 3
                     for partition_id, last_message in last_message_by_partition.items():
-                        if last_message.partition_context:
-                            for attempt in range(1, max_checkpoint_attempts + 1):
-                                try:
-                                    await last_message.partition_context.update_checkpoint(
-                                        last_message.event_data
-                                    )
-                                    checkpoints_updated += 1
-                                    logger.info(
-                                        f"✅ Updated SDK checkpoint for partition {partition_id}: "
-                                        f"offset={last_message.event_data.offset}, sequence={last_message.sequence_number}"
-                                    )
-                                    break
-                                except Exception as e:
-                                    logger.error(
-                                        "❌ Failed to update SDK checkpoint for partition %s (attempt %s/%s): %s",
-                                        partition_id,
-                                        attempt,
-                                        max_checkpoint_attempts,
-                                        e,
-                                        exc_info=True,
-                                    )
-                                    logfire.error(
-                                        "Checkpoint update failed",
-                                        partition_id=partition_id,
-                                        attempt=attempt,
-                                        max_attempts=max_checkpoint_attempts,
-                                        error=str(e),
-                                    )
-                                    if attempt < max_checkpoint_attempts:
-                                        await asyncio.sleep(2 ** (attempt - 1))
-                        else:
-                            logger.warning(
-                                f"⚠️ No partition_context for partition {partition_id}, cannot update SDK checkpoint"
+                        if not last_message.partition_context:
+                            raise RuntimeError(
+                                f"No partition_context for partition {partition_id}; "
+                                "cannot update SDK checkpoint"
                             )
+
+                        checkpoint_updated = False
+                        last_checkpoint_error: Exception | None = None
+                        for attempt in range(1, max_checkpoint_attempts + 1):
+                            try:
+                                await last_message.partition_context.update_checkpoint(
+                                    last_message.event_data
+                                )
+                                checkpoints_updated += 1
+                                checkpoint_updated = True
+                                logger.info(
+                                    f"✅ Updated SDK checkpoint for partition {partition_id}: "
+                                    f"offset={last_message.event_data.offset}, sequence={last_message.sequence_number}"
+                                )
+                                break
+                            except Exception as e:
+                                last_checkpoint_error = e
+                                logger.error(
+                                    "❌ Failed to update SDK checkpoint for partition %s (attempt %s/%s): %s",
+                                    partition_id,
+                                    attempt,
+                                    max_checkpoint_attempts,
+                                    e,
+                                    exc_info=True,
+                                )
+                                logfire.error(
+                                    "Checkpoint update failed",
+                                    partition_id=partition_id,
+                                    attempt=attempt,
+                                    max_attempts=max_checkpoint_attempts,
+                                    error=str(e),
+                                )
+                                if attempt < max_checkpoint_attempts:
+                                    await asyncio.sleep(2 ** (attempt - 1))
+
+                        if not checkpoint_updated:
+                            raise RuntimeError(
+                                f"Failed to update SDK checkpoint for partition {partition_id} "
+                                f"after {max_checkpoint_attempts} attempts"
+                            ) from last_checkpoint_error
 
                     span.set_attribute("checkpoints_updated", checkpoints_updated)
                     span.set_attribute("partitions_count", len(last_message_by_partition))
@@ -1058,26 +1277,33 @@ class EventHubAsyncConsumer:
                     self.stats["batches_processed"] += 1
                     span.set_attribute("total_batches_processed", self.stats["batches_processed"])
                     # Store checkpoint data in stats for monitoring (sequence numbers for display)
-                    partition_checkpoints = batch.get_checkpoint_data()
+                    partition_checkpoints: dict[str, int] = {}
+                    for message in messages:
+                        current_sequence = partition_checkpoints.get(message.partition_id)
+                        if current_sequence is None or message.sequence_number > current_sequence:
+                            partition_checkpoints[message.partition_id] = message.sequence_number
                     self.stats["last_checkpoint"] = partition_checkpoints.copy()
 
                     logger.info(
                         f"✅ Batch processed successfully! Total batches: {self.stats['batches_processed']}, "
                         f"Total messages: {self.stats['messages_received']}"
                     )
+                    return True
                 else:
                     logger.error("❌ Message processor returned failure")
                     logfire.error(
-                        "Message processor returned failure", batch_size=len(batch.messages)
+                        "Message processor returned failure", batch_size=len(messages)
                     )
                     span.set_attribute("processor_failure", True)
+                    return False
 
             except Exception as e:
                 logger.error(f"❌ Error processing batch: {e}", exc_info=True)
                 logfire.error(
-                    "Batch processing error", error=str(e), batch_size=len(batch.messages)
+                    "Batch processing error", error=str(e), batch_size=len(messages)
                 )
                 span.set_attribute("error", str(e))
+                return False
 
     def get_stats(self) -> dict[str, Any]:
         """Get consumer statistics."""

--- a/src/consumers/eventhub.py
+++ b/src/consumers/eventhub.py
@@ -30,6 +30,7 @@ from consumers.checkpoints import (
     CheckpointManagerProtocol,
     PostgresCheckpointManager,
     PostgresCheckpointStore,
+    SingleConsumerSnowflakeCheckpointStore,
     SnowflakeCheckpointManager,
     SnowflakeCheckpointStore,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "MessageBatch",
     "PostgresCheckpointManager",
     "PostgresCheckpointStore",
+    "SingleConsumerSnowflakeCheckpointStore",
     "SnowflakeCheckpointManager",
     "SnowflakeCheckpointStore",
     "_convert_bytes_to_str",
@@ -85,6 +87,7 @@ class EventHubAsyncConsumer:
         control_table: str | None = None,
         control_table_backend: str = "snowflake",
         control_postgres_config: PostgresConnectionConfig | None = None,
+        control_ownership_mode: str = "durable",
         capture_messages: bool = False,
         capture_messages_dir: str = "messages",
     ):
@@ -110,6 +113,7 @@ class EventHubAsyncConsumer:
         self.control_table = control_table or "INGESTION_STATUS"
         self.control_table_backend = control_table_backend.strip().lower()
         self.control_postgres_config = control_postgres_config
+        self.control_ownership_mode = control_ownership_mode.strip().lower()
         self.checkpoint_backend_label = (
             "Postgres" if self.control_table_backend == "postgres" else "Snowflake"
         )
@@ -131,6 +135,9 @@ class EventHubAsyncConsumer:
         self._batch_counter = 0
         self._batch_lock = asyncio.Lock()
         self._processing_lock = asyncio.Lock()
+        self._active_event_callbacks = 0
+        self._event_callbacks_drained = asyncio.Event()
+        self._event_callbacks_drained.set()
         self._detached_batches: list[MessageBatch] = []
         self._restored_detached_batch_ids: set[str] = set()
         self._receive_error: Exception | None = None
@@ -647,7 +654,17 @@ class EventHubAsyncConsumer:
                     control_schema=self.control_schema,
                     control_table=self.control_table,
                 )
-                checkpoint_store = SnowflakeCheckpointStore(self.checkpoint_manager)
+                if self.control_ownership_mode == "local_single_consumer_smoke":
+                    logger.warning(
+                        "Using local in-memory Snowflake partition ownership. This mode is "
+                        "only for a single-consumer smoke test; do not run multiple consumers "
+                        "with the same consumer group."
+                    )
+                    checkpoint_store = SingleConsumerSnowflakeCheckpointStore(
+                        self.checkpoint_manager
+                    )
+                else:
+                    checkpoint_store = SnowflakeCheckpointStore(self.checkpoint_manager)
 
             # Create Azure SDK-compatible checkpoint store
             logger.info("🔐 Creating checkpoint store...")
@@ -855,6 +872,9 @@ class EventHubAsyncConsumer:
                 await asyncio.gather(*self.tasks, return_exceptions=True)
                 logger.info("✅ All tasks completed")
             self.tasks.clear()
+            await self._wait_for_active_event_callbacks()
+            await self._wait_for_active_batch_processing()
+            await self._restore_detached_batches_for_shutdown()
         except Exception as e:
             logger.error(f"❌ Error during initial shutdown steps: {e}", exc_info=True)
             raise
@@ -935,88 +955,92 @@ class EventHubAsyncConsumer:
         because it would be too expensive (thousands of events per second).
         Instead, we log to console and only create spans for batch operations.
         """
-        if not self.running:
-            logger.debug("Consumer not running, ignoring event")
-            return
-
-        if event is None:
-            logger.debug(f"Received None event on partition {partition_context.partition_id}")
-            return
-
+        self._begin_event_callback()
         try:
-            # Log FIRST message received on each partition to verify checkpoint resumption
-            if partition_context.partition_id not in self._first_message_logged:
-                logger.warning(
-                    f"🎯 FIRST MESSAGE on partition {partition_context.partition_id}: "
-                    f"offset={event.offset}, sequence={event.sequence_number}, "
-                    f"enqueued_time={event.enqueued_time}"
-                )
-                # Log first message to Logfire for monitoring checkpoint resumption
-                logfire.info(
-                    "First message on partition",
-                    partition_id=partition_context.partition_id,
-                    offset=event.offset,
-                    sequence_number=event.sequence_number,
-                )
-                self._first_message_logged.add(partition_context.partition_id)
-
-            logger.debug(
-                f"📨 Received event on partition {partition_context.partition_id}, "
-                f"offset: {event.offset}, sequence: {event.sequence_number}, "
-                f"enqueued_time: {event.enqueued_time}"
-            )
-
-            # Ensure sequence_number is not None
-            if event.sequence_number is None:
-                logger.warning(
-                    f"Received event with None sequence_number on partition {partition_context.partition_id}"
-                )
+            if not self.running:
+                logger.debug("Consumer not running, ignoring event")
                 return
 
-            # Optional capture of the raw message (as received)
-            self._enqueue_capture(partition_context.partition_id, event)
+            if event is None:
+                logger.debug(f"Received None event on partition {partition_context.partition_id}")
+                return
 
-            # Create message wrapper
-            message = EventHubMessage(
-                event_data=event,
-                partition_id=partition_context.partition_id,
-                sequence_number=event.sequence_number,
-                eventhub_namespace=self.eventhub_config.namespace,
-                eventhub_name=self.eventhub_config.name,
-                consumer_group=self.eventhub_config.consumer_group,
-            )
+            try:
+                # Log FIRST message received on each partition to verify checkpoint resumption
+                if partition_context.partition_id not in self._first_message_logged:
+                    logger.warning(
+                        f"🎯 FIRST MESSAGE on partition {partition_context.partition_id}: "
+                        f"offset={event.offset}, sequence={event.sequence_number}, "
+                        f"enqueued_time={event.enqueued_time}"
+                    )
+                    # Log first message to Logfire for monitoring checkpoint resumption
+                    logfire.info(
+                        "First message on partition",
+                        partition_id=partition_context.partition_id,
+                        offset=event.offset,
+                        sequence_number=event.sequence_number,
+                    )
+                    self._first_message_logged.add(partition_context.partition_id)
 
-            # Store partition_context with message for later checkpoint update
-            message.partition_context = partition_context
-
-            self.stats["messages_received"] += 1
-
-            logger.debug(
-                f"✅ Message {self.stats['messages_received']} added to batch. "
-                f"Current batch size: {len(self.current_batch.messages) if self.current_batch else 0}"
-            )
-
-            batch_to_process: MessageBatch | None = None
-            async with self._batch_lock:
-                if self.current_batch and self.current_batch.add_message(message):
-                    batch_to_process = self.current_batch
-                    self._detached_batches.append(batch_to_process)
-                    self._restored_detached_batch_ids.discard(batch_to_process.batch_id)
-                    self.current_batch = self._new_batch(reason="after_process")
-
-            if batch_to_process:
-                logger.info(
-                    f"🔄 Batch ready for processing ({len(batch_to_process.messages)} messages)"
+                logger.debug(
+                    f"📨 Received event on partition {partition_context.partition_id}, "
+                    f"offset: {event.offset}, sequence: {event.sequence_number}, "
+                    f"enqueued_time: {event.enqueued_time}"
                 )
-                await self._process_detached_batch(batch_to_process)
 
-        except Exception as e:
-            logger.error(f"Error processing event: {e}", exc_info=True)
-            logfire.error(
-                "Error processing event",
-                error=str(e),
-                partition_id=partition_context.partition_id,
-            )
+                # Ensure sequence_number is not None
+                if event.sequence_number is None:
+                    logger.warning(
+                        f"Received event with None sequence_number on partition {partition_context.partition_id}"
+                    )
+                    return
+
+                # Optional capture of the raw message (as received)
+                self._enqueue_capture(partition_context.partition_id, event)
+
+                # Create message wrapper
+                message = EventHubMessage(
+                    event_data=event,
+                    partition_id=partition_context.partition_id,
+                    sequence_number=event.sequence_number,
+                    eventhub_namespace=self.eventhub_config.namespace,
+                    eventhub_name=self.eventhub_config.name,
+                    consumer_group=self.eventhub_config.consumer_group,
+                )
+
+                # Store partition_context with message for later checkpoint update
+                message.partition_context = partition_context
+
+                self.stats["messages_received"] += 1
+
+                logger.debug(
+                    f"✅ Message {self.stats['messages_received']} added to batch. "
+                    f"Current batch size: {len(self.current_batch.messages) if self.current_batch else 0}"
+                )
+
+                batch_to_process: MessageBatch | None = None
+                async with self._batch_lock:
+                    if self.current_batch and self.current_batch.add_message(message):
+                        batch_to_process = self.current_batch
+                        self._detached_batches.append(batch_to_process)
+                        self._restored_detached_batch_ids.discard(batch_to_process.batch_id)
+                        self.current_batch = self._new_batch(reason="after_process")
+
+                if batch_to_process:
+                    logger.info(
+                        f"🔄 Batch ready for processing ({len(batch_to_process.messages)} messages)"
+                    )
+                    await self._process_detached_batch(batch_to_process)
+
+            except Exception as e:
+                logger.error(f"Error processing event: {e}", exc_info=True)
+                logfire.error(
+                    "Error processing event",
+                    error=str(e),
+                    partition_id=partition_context.partition_id,
+                )
+        finally:
+            self._finish_event_callback()
 
     async def _batch_timeout_handler(self) -> None:
         """Handle batch timeout - process partial batches."""
@@ -1134,6 +1158,67 @@ class EventHubAsyncConsumer:
                 self._restored_detached_batch_ids.discard(batch.batch_id)
             else:
                 self._restored_detached_batch_ids.clear()
+
+    def _begin_event_callback(self) -> None:
+        self._active_event_callbacks += 1
+        self._event_callbacks_drained.clear()
+
+    def _finish_event_callback(self) -> None:
+        self._active_event_callbacks = max(0, self._active_event_callbacks - 1)
+        if self._active_event_callbacks == 0:
+            self._event_callbacks_drained.set()
+
+    async def _wait_for_active_event_callbacks(self) -> None:
+        if self._active_event_callbacks == 0:
+            return
+
+        logger.info(
+            "⏳ Waiting for %s active Event Hub callback(s) before shutdown drain...",
+            self._active_event_callbacks,
+        )
+        # EventHubConsumerClient.close stops retrieval, but receive() may already
+        # have dispatched callbacks. Wait for those callbacks before draining the
+        # final batch so Snowflake clients are still open for checkpoint-safe work.
+        # https://learn.microsoft.com/python/api/azure-eventhub/azure.eventhub.eventhubconsumerclient
+        await self._event_callbacks_drained.wait()
+
+    async def _wait_for_active_batch_processing(self) -> None:
+        if not self._processing_lock.locked():
+            return
+
+        logger.info("⏳ Waiting for active batch processing to finish before shutdown...")
+        async with self._processing_lock:
+            return
+
+    async def _restore_detached_batches_for_shutdown(self) -> None:
+        async with self._batch_lock:
+            if not self._detached_batches:
+                return
+
+            restored_batch = self._detached_batches[0]
+            for queued_batch in self._detached_batches[1:]:
+                if queued_batch is restored_batch:
+                    continue
+                for message in queued_batch.messages:
+                    restored_batch.add_message(message)
+
+            if (
+                self.current_batch
+                and self.current_batch not in self._detached_batches
+                and self.current_batch.messages
+            ):
+                for message in self.current_batch.messages:
+                    restored_batch.add_message(message)
+
+            # The Azure SDK can still have an on_event callback queued while
+            # shutdown starts. Restore detached batches before Snowflake is closed
+            # so final checkpoint-safe ingestion happens while downstream clients
+            # are still alive.
+            self.current_batch = restored_batch
+            self._restored_detached_batch_ids.update(
+                batch.batch_id for batch in self._detached_batches
+            )
+            self._detached_batches.clear()
 
     async def _stop_after_batch_failure(self) -> None:
         self.running = False
@@ -1330,6 +1415,7 @@ async def create_eventhub_consumer(
     control_table: str | None = None,
     control_table_backend: str = "snowflake",
     control_postgres_config: PostgresConnectionConfig | None = None,
+    control_ownership_mode: str = "durable",
 ) -> EventHubAsyncConsumer:
     """Factory function to create an EventHub consumer."""
     return EventHubAsyncConsumer(
@@ -1346,6 +1432,7 @@ async def create_eventhub_consumer(
         control_table=control_table,
         control_table_backend=control_table_backend,
         control_postgres_config=control_postgres_config,
+        control_ownership_mode=control_ownership_mode,
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -182,14 +182,26 @@ def check_credentials() -> None:
 
     # Show conclusion
     console.print("\n[bold yellow]⚠️  CONCLUSION:[/bold yellow]")
-    console.print(
-        "[green]• Event Hub receiver uses AZURE CLI credentials unless EVENTHUBNAME_{N}_CONNECTION_STRING is set[/green]"
-    )
-    console.print("[green]• Ensure your CLI user has required RBAC roles[/green]")
-    console.print("\n[bold]Next Steps:[/bold]")
-    console.print("1. Go to Azure Portal → EventHub Namespace")
-    console.print("2. Access Control (IAM) → Role Assignments")
-    console.print("3. Verify your user has 'Azure Event Hubs Data Receiver' role")
+    if has_msi:
+        console.print(
+            "[yellow]• System will use MANAGED IDENTITY for EventHub authentication[/yellow]"
+        )
+        console.print("[yellow]• Your Azure CLI user permissions are NOT relevant[/yellow]")
+        console.print("\n[bold]Next Steps:[/bold]")
+        console.print("1. Identify the Managed Identity resource in Azure Portal")
+        console.print("2. Go to EventHub Namespace → Access Control (IAM)")
+        console.print("3. Verify Managed Identity has 'Azure Event Hubs Data Receiver' role")
+        console.print("\n[bold]To force using Azure CLI credentials instead:[/bold]")
+        console.print("[dim]Set EVENTHUBNAME_{N}_CREDENTIAL_MODE=azure_cli[/dim]")
+    else:
+        console.print(
+            "[green]• System will use AZURE CLI credentials for EventHub authentication[/green]"
+        )
+        console.print("[green]• Ensure your CLI user has required RBAC roles[/green]")
+        console.print("\n[bold]Next Steps:[/bold]")
+        console.print("1. Go to Azure Portal → EventHub Namespace")
+        console.print("2. Access Control (IAM) → Role Assignments")
+        console.print("3. Verify your user has 'Azure Event Hubs Data Receiver' role")
 
 
 @app.command()
@@ -529,6 +541,10 @@ def _show_detailed_config(config: EvSnowConfig) -> None:
             table.add_row("Max Batch Size", str(eh_config.max_batch_size))
             table.add_row("Max Wait Time", f"{eh_config.max_wait_time}s")
             table.add_row("Prefetch Count", str(eh_config.prefetch_count))
+            table.add_row("Credential Mode", str(eh_config.credential_mode))
+            table.add_row("Retry Total", str(eh_config.retry_total))
+            table.add_row("Retry Mode", str(eh_config.retry_mode))
+            table.add_row("Load Balancing", str(eh_config.load_balancing_strategy))
 
             console.print(table)
 

--- a/src/main.py
+++ b/src/main.py
@@ -158,14 +158,16 @@ def check_credentials() -> None:
         console.print(f"   [dim]{e!s}[/dim]\n")
 
     # Managed Identity
+    has_msi = False
     try:
         _msi_cred = ManagedIdentityCredential()
+        has_msi = True
         console.print("✅ [yellow bold]Managed Identity[/yellow bold] - Available")
         console.print(
             "   [dim]Available for services that use DefaultAzureCredential, such as Postgres azure_token auth.[/dim]"
         )
         console.print(
-            "   [yellow]Event Hub consumption does not use Managed Identity in the current runtime path.[/yellow]\n"
+            "   [yellow]Event Hub consumption may use Managed Identity when credential_mode=default.[/yellow]\n"
         )
     except Exception:
         console.print("❌ [dim]Managed Identity - Not available[/dim]")
@@ -184,9 +186,9 @@ def check_credentials() -> None:
     console.print("\n[bold yellow]⚠️  CONCLUSION:[/bold yellow]")
     if has_msi:
         console.print(
-            "[yellow]• System will use MANAGED IDENTITY for EventHub authentication[/yellow]"
+            "[yellow]• Event Hub receiver may use MANAGED IDENTITY through DefaultAzureCredential[/yellow]"
         )
-        console.print("[yellow]• Your Azure CLI user permissions are NOT relevant[/yellow]")
+        console.print("[yellow]• Verify both managed identity and Azure CLI RBAC if configs differ[/yellow]")
         console.print("\n[bold]Next Steps:[/bold]")
         console.print("1. Identify the Managed Identity resource in Azure Portal")
         console.print("2. Go to EventHub Namespace → Access Control (IAM)")

--- a/src/main.py
+++ b/src/main.py
@@ -188,7 +188,9 @@ def check_credentials() -> None:
         console.print(
             "[yellow]• Event Hub receiver may use MANAGED IDENTITY through DefaultAzureCredential[/yellow]"
         )
-        console.print("[yellow]• Verify both managed identity and Azure CLI RBAC if configs differ[/yellow]")
+        console.print(
+            "[yellow]• Verify both managed identity and Azure CLI RBAC if configs differ[/yellow]"
+        )
         console.print("\n[bold]Next Steps:[/bold]")
         console.print("1. Identify the Managed Identity resource in Azure Portal")
         console.print("2. Go to EventHub Namespace → Access Control (IAM)")

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -141,6 +141,7 @@ class PipelineMapping:
                 control_table=self.pipeline_config.target_table,
                 control_table_backend=self.pipeline_config.control_table_backend,
                 control_postgres_config=self.pipeline_config.control_postgres,
+                control_ownership_mode=self.pipeline_config.control_ownership_mode,
                 capture_messages=bool(getattr(self.pipeline_config, "capture_messages", False)),
                 capture_messages_dir=str(
                     getattr(self.pipeline_config, "capture_messages_dir", "messages")

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -17,7 +17,6 @@ import logging
 import os
 import re
 import signal
-from collections import defaultdict
 from datetime import UTC, datetime
 from typing import Any
 

--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -91,6 +91,13 @@ class PipelineMapping:
             "errors": [],
         }
 
+    def _channel_name_for_partition(self, partition_id: str) -> str:
+        # Snowflake offset tokens are tracked per channel, so each Event Hub
+        # partition needs a stable channel namespace for replay-safe checkpointing.
+        partition_segment = re.sub(r"[^A-Za-z0-9_-]", "-", str(partition_id).strip())
+        partition_segment = re.sub(r"-{2,}", "-", partition_segment).strip("-_")
+        return f"{self.channel_name}-p-{partition_segment or 'unknown'}"
+
     def start(self) -> None:
         """Start the mapping components."""
         if self.running:
@@ -228,82 +235,67 @@ class PipelineMapping:
                 return False
 
             try:
-                messages_by_partition: defaultdict[str, list[EventHubMessage]] = defaultdict(list)
-                for message in messages:
-                    messages_by_partition[str(message.partition_id)].append(message)
+                if not messages:
+                    logger.debug("No messages to process")
+                    span.set_attribute("success", True)
+                    return True
 
-                span.set_attribute("base_channel_name", self.channel_name)
+                messages_by_partition: dict[str, list[EventHubMessage]] = {}
+                for message in messages:
+                    messages_by_partition.setdefault(message.partition_id, []).append(message)
+
                 span.set_attribute("partition_count", len(messages_by_partition))
 
-                success = True
-                failed_partition_id: str | None = None
-                failed_partition_count = 0
-                for partition_id in sorted(messages_by_partition):
-                    partition_messages = sorted(
-                        messages_by_partition[partition_id],
-                        key=lambda msg: msg.sequence_number,
-                    )
+                for partition_id, partition_messages in messages_by_partition.items():
                     logger.debug(
-                        "Converting %d messages from partition %s to dict format...",
+                        "Converting %s messages from partition %s to dict format...",
                         len(partition_messages),
                         partition_id,
                     )
                     data_batch = [msg.to_dict() for msg in partition_messages]
-
-                    # Log first message as sample
                     if data_batch:
                         logger.debug(f"Sample message: {str(data_batch[0])[:200]}...")
 
-                    channel_name = _partition_channel_name(self.channel_name, partition_id)
-
+                    channel_name = self._channel_name_for_partition(partition_id)
                     logger.debug(
-                        "Sending partition batch of %d messages to Snowflake "
-                        "(channel: %s, partition: %s)...",
+                        "Sending %s messages to Snowflake (channel: %s, partition: %s)...",
                         len(data_batch),
                         channel_name,
                         partition_id,
                     )
 
-                    partition_success = self.snowflake_client.ingest_batch(
+                    success = self.snowflake_client.ingest_batch(
                         channel_name=channel_name,
                         data_batch=data_batch,
                         partition_id=partition_id,
                     )
 
-                    if not partition_success:
-                        success = False
-                        failed_partition_id = partition_id
-                        failed_partition_count = len(partition_messages)
+                    if not success:
                         logger.error(
-                            "❌ Failed to ingest %d messages from partition %s",
+                            "❌ Failed to ingest %s messages from partition %s",
                             len(partition_messages),
                             partition_id,
                         )
-                        break
+                        self.stats["errors"].append(
+                            {
+                                "timestamp": datetime.now(UTC),
+                                "message_count": len(partition_messages),
+                                "partition_id": partition_id,
+                            }
+                        )
+                        span.set_attribute("success", False)
+                        return False
 
-                if success:
-                    self.stats["messages_processed"] += len(messages)
-                    self.stats["batches_processed"] += 1
-                    self.stats["last_activity"] = datetime.now(UTC)
-                    logger.info(
-                        f"✅ Processed batch: {len(messages)} messages. "
-                        f"Total: {self.stats['messages_processed']}"
-                    )
-                    span.set_attribute("success", True)
-                    span.set_attribute("total_messages_processed", self.stats["messages_processed"])
-                    return True
-                else:
-                    logger.error(f"❌ Failed to ingest {len(messages)} messages")
-                    error_entry: dict[str, Any] = {
-                        "timestamp": datetime.now(UTC),
-                        "message_count": len(messages),
-                    }
-                    if failed_partition_id is not None:
-                        error_entry["partition_id"] = failed_partition_id
-                        error_entry["partition_message_count"] = failed_partition_count
-                    self.stats["errors"].append(error_entry)
-                    span.set_attribute("success", False)
-                    return False
+                self.stats["messages_processed"] += len(messages)
+                self.stats["batches_processed"] += 1
+                self.stats["last_activity"] = datetime.now(UTC)
+                logger.info(
+                    f"✅ Processed batch: {len(messages)} messages. "
+                    f"Total: {self.stats['messages_processed']}"
+                )
+                span.set_attribute("success", True)
+                span.set_attribute("total_messages_processed", self.stats["messages_processed"])
+                return True
 
             except Exception as e:
                 logger.error(f"❌ Error processing messages: {e}", exc_info=True)

--- a/src/streaming/snowflake_high_performance.py
+++ b/src/streaming/snowflake_high_performance.py
@@ -19,9 +19,13 @@ from typing import Any
 
 import logfire
 
-# Snowflake High-Performance Streaming SDK
-from snowflake.ingest.streaming import StreamingIngestClient
-from snowflake.ingest.streaming.channel_status import ChannelStatus
+# Snowpipe Streaming exposes ChannelStatus at the package root in SDK 1.2.0,
+# while older examples import it from a channel_status submodule.
+try:
+    from snowflake.ingest.streaming import ChannelStatus, StreamingIngestClient
+except ImportError:  # pragma: no cover - compatibility with older SDK layouts
+    from snowflake.ingest.streaming import StreamingIngestClient
+    from snowflake.ingest.streaming.channel_status import ChannelStatus
 
 from streaming.base import SnowflakeStreamingClientBase
 from utils.config import SnowflakeConfig, SnowflakeConnectionConfig
@@ -334,18 +338,23 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
             )
             raise
 
-    def _maybe_check_channel_status(self, channel_name: str) -> None:
+    def _maybe_check_channel_status(
+        self,
+        channel_name: str,
+        start_offset_token: str | None = None,
+        end_offset_token: str | None = None,
+        force: bool = False,
+    ) -> None:
         if self.streaming_client is None:
             return
 
-        interval = getattr(self.snowflake_config, "channel_status_interval_seconds", 0)
-        if interval <= 0:
+        interval = getattr(self.snowflake_config, "channel_status_interval_seconds", 60)
+        if interval <= 0 and not force:
             return
 
         now = datetime.now(UTC)
-        last_check_at = self._last_channel_status_check_at_by_channel.get(channel_name)
-        if last_check_at is not None:
-            elapsed = (now - last_check_at).total_seconds()
+        if not force and self._last_channel_status_check_at is not None:
+            elapsed = (now - self._last_channel_status_check_at).total_seconds()
             if elapsed < interval:
                 return
 
@@ -363,11 +372,15 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
                 channel_name=channel_name,
                 error=str(exc),
             )
+            if force:
+                raise RuntimeError(f"Failed to fetch channel status for {channel_name}") from exc
             return
 
         status = statuses.get(channel_name)
         if status is None:
             logger.warning("No channel status returned for %s", channel_name)
+            if force:
+                raise RuntimeError(f"No channel status returned for {channel_name}")
             return
 
         self.stats["channel_status_checks"] += 1
@@ -395,7 +408,11 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
             else None,
         )
 
-        if status.rows_error_count > 0 or status.last_error_message:
+        if self._channel_status_has_row_errors(
+            status,
+            start_offset_token=start_offset_token,
+            end_offset_token=end_offset_token,
+        ):
             logger.warning(
                 "Channel %s reported errors: status=%s rows_error=%s last_error=%s",
                 status.channel_name,
@@ -411,10 +428,8 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
                 last_error_message=status.last_error_message,
             )
             raise RuntimeError(
-                "Snowflake channel reported row errors: "
-                f"channel={status.channel_name} status={status.status_code} "
-                f"rows_error={status.rows_error_count} "
-                f"last_error={status.last_error_message}"
+                f"Snowflake channel {status.channel_name} reported row errors: "
+                f"{status.last_error_message or status.rows_error_count}"
             )
 
         if self._is_channel_status_error(status):
@@ -430,13 +445,11 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
                 last_error_message=status.last_error_message,
             )
             self._reopen_channel(status.channel_name)
-            raise RuntimeError(
-                "Snowflake channel status indicates an error: "
-                f"channel={status.channel_name} status={status.status_code} "
-                f"last_error={status.last_error_message}"
-            )
-
-        self._last_channel_status_check_at_by_channel[channel_name] = now
+            if force:
+                raise RuntimeError(
+                    f"Snowflake channel {status.channel_name} status indicates an error: "
+                    f"{status.status_code}"
+                )
 
     @staticmethod
     def _is_channel_status_error(status: ChannelStatus) -> bool:
@@ -448,6 +461,63 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
             or "MUST_BE_REOPENED" in status_code
             or "INVALID" in status_code
         )
+
+    @staticmethod
+    def _parse_offset_token(offset_token: str | None) -> tuple[str, int] | None:
+        if not isinstance(offset_token, str):
+            return None
+
+        partition_id, separator, sequence_number = offset_token.rpartition("_")
+        if not separator:
+            return None
+
+        try:
+            return partition_id, int(sequence_number)
+        except ValueError:
+            return None
+
+    @classmethod
+    def _offset_token_in_range(
+        cls,
+        candidate_token: str | None,
+        start_offset_token: str | None,
+        end_offset_token: str | None,
+    ) -> bool:
+        candidate = cls._parse_offset_token(candidate_token)
+        start = cls._parse_offset_token(start_offset_token)
+        end = cls._parse_offset_token(end_offset_token)
+        if candidate is None or start is None or end is None:
+            return False
+
+        candidate_partition, candidate_sequence = candidate
+        start_partition, start_sequence = start
+        end_partition, end_sequence = end
+        return (
+            candidate_partition == start_partition == end_partition
+            and start_sequence <= candidate_sequence <= end_sequence
+        )
+
+    @classmethod
+    def _channel_status_has_row_errors(
+        cls,
+        status: ChannelStatus,
+        start_offset_token: str | None,
+        end_offset_token: str | None,
+    ) -> bool:
+        if not ((status.rows_error_count or 0) > 0 or status.last_error_message):
+            return False
+
+        error_upper_bound = getattr(status, "last_error_offset_token_upper_bound", None)
+        if error_upper_bound:
+            return cls._offset_token_in_range(
+                error_upper_bound,
+                start_offset_token,
+                end_offset_token,
+            )
+
+        # Without an error offset token, fail closed so Event Hub checkpointing
+        # cannot advance past a Snowflake channel that reports row errors.
+        return True
 
     def _reopen_channel(self, channel_name: str) -> None:
         if self.streaming_client is None:
@@ -598,107 +668,104 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
         )
 
     @staticmethod
-    def _sequence_number_for_row(row: dict[str, Any], fallback: int) -> int:
-        sequence_number = row.get("sequence_number", fallback)
+    def _offset_token_for_row(
+        row: dict[str, Any],
+        partition_id: str,
+    ) -> str:
+        # Snowflake treats this value as an application offset token, not a row ID.
+        # Keep it partition-scoped so replay checks are comparable within one channel.
+        sequence_number = row.get("sequence_number")
+        if sequence_number is None:
+            raise ValueError("Cannot build Snowflake offset token without sequence_number")
         try:
-            return int(sequence_number)
-        except (TypeError, ValueError):
-            logger.warning(
-                "Invalid sequence_number %r; using batch index %s as offset token",
-                sequence_number,
-                fallback,
-            )
-            return fallback
+            sequence_number = int(sequence_number)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Cannot build Snowflake offset token from sequence_number={sequence_number!r}"
+            ) from exc
+        return f"{partition_id}_{sequence_number}"
 
     @staticmethod
-    def _offset_token_for_sequence(sequence_number: int) -> str:
-        return str(sequence_number)
+    def _offset_token_reached(committed_token: str | None, target_token: str) -> bool:
+        committed = SnowflakeHighPerformanceStreamingClient._parse_offset_token(committed_token)
+        target = SnowflakeHighPerformanceStreamingClient._parse_offset_token(target_token)
+        if committed is None or target is None:
+            return False
+        committed_partition, committed_sequence = committed
+        target_partition, target_sequence = target
+        if committed_partition != target_partition:
+            return False
+        return committed_sequence >= target_sequence
 
-    @staticmethod
-    def _offset_sequence_from_token(offset_token: Any) -> int | None:
-        if offset_token is None:
-            return None
-
-        if isinstance(offset_token, int):
-            return offset_token
-
-        token = str(offset_token)
-        if not token:
-            return None
-
-        if token.lstrip("-").isdigit():
-            return int(token)
-
-        matches = re.findall(r"-?\d+", token)
-        if not matches:
-            return None
-        return int(matches[-1])
-
-    @classmethod
-    def _offset_token_has_reached(cls, committed_token: Any, expected_token: str) -> bool:
-        committed_sequence = cls._offset_sequence_from_token(committed_token)
-        expected_sequence = cls._offset_sequence_from_token(expected_token)
-
-        if committed_sequence is not None and expected_sequence is not None:
-            return committed_sequence >= expected_sequence
-
-        return committed_token == expected_token
-
-    @classmethod
-    def _is_committed(cls, offset_token: str, latest_committed_offset_token: Any) -> bool:
-        return cls._offset_token_has_reached(latest_committed_offset_token, offset_token)
-
-    @staticmethod
-    def _close_with_flush(closeable: Any) -> None:
-        try:
-            closeable.close(wait_for_flush=True)
-        except TypeError:
-            closeable.close()
-
-    @staticmethod
-    def _append_rows(
+    def _append_rows_to_channel(
+        self,
         channel: Any,
         rows: list[dict[str, Any]],
         offset_tokens: list[str],
     ) -> None:
-        start_token = offset_tokens[0]
-        end_token = offset_tokens[-1]
+        # Prefer the SDK batch API so Snowflake receives one offset-token range for
+        # the append: https://docs.snowflake.com/en/user-guide/snowpipe-streaming-sdk-python/reference/latest/api/snowflake/ingest/streaming/index
         append_rows = getattr(channel, "append_rows", None)
         if callable(append_rows):
-            append_rows(rows, start_offset_token=start_token, end_offset_token=end_token)
-            return
-
-        append_row = getattr(channel, "append_row", None)
-        if not callable(append_row):
-            raise AttributeError("Snowflake streaming channel has no append_rows or append_row API")
-
-        for row_payload, offset_token in zip(rows, offset_tokens, strict=True):
-            try:
-                append_row(row_payload, offset_token=offset_token)
-            except TypeError:
-                append_row(row_payload, offset_token)
-
-    def _wait_for_commit(self, channel: Any, expected_token: str) -> None:
-        timeout_seconds = getattr(self.snowflake_config, "connection_timeout_seconds", None)
-
-        wait_for_commit = getattr(channel, "wait_for_commit", None)
-        if callable(wait_for_commit):
-            wait_for_commit(
-                lambda committed_token: self._offset_token_has_reached(
-                    committed_token, expected_token
-                ),
-                timeout_seconds=timeout_seconds,
+            append_rows(
+                rows,
+                start_offset_token=offset_tokens[0],
+                end_offset_token=offset_tokens[-1],
             )
             return
 
-        wait_for_flush = getattr(channel, "wait_for_flush", None)
-        if callable(wait_for_flush):
-            wait_for_flush(timeout_seconds=timeout_seconds)
-            return
+        for row, offset_token in zip(rows, offset_tokens, strict=True):
+            channel.append_row(row, offset_token)
 
-        flush = getattr(channel, "flush", None)
-        if callable(flush):
-            flush()
+    def _wait_for_channel_commit(
+        self,
+        channel: Any,
+        channel_name: str,
+        end_offset_token: str,
+    ) -> Any | None:
+        # Event Hub checkpoints must not advance until Snowflake has committed the
+        # token range; wait_for_commit is the explicit SDK confirmation point.
+        flush_result = None
+        timeout_seconds = self.snowflake_config.connection_timeout_seconds
+
+        initiate_flush = getattr(channel, "initiate_flush", None)
+        if callable(initiate_flush):
+            flush_result = initiate_flush()
+            logger.debug(
+                "Initiated flush for channel %s after append (result=%s)",
+                channel_name,
+                flush_result,
+            )
+        else:
+            flush = getattr(channel, "flush", None)
+            if callable(flush):
+                flush_result = flush()
+                logger.debug(
+                    "Flushed channel %s after append (result=%s)",
+                    channel_name,
+                    flush_result,
+                )
+
+        wait_for_commit = getattr(channel, "wait_for_commit", None)
+        if not callable(wait_for_commit):
+            raise RuntimeError(
+                "Snowflake channel does not support wait_for_commit; "
+                "cannot safely advance Event Hub checkpoints"
+            )
+
+        wait_for_commit(
+            lambda committed_token: self._offset_token_reached(
+                committed_token,
+                end_offset_token,
+            ),
+            timeout_seconds=timeout_seconds,
+        )
+        logger.debug(
+            "Committed channel %s through offset token %s",
+            channel_name,
+            end_offset_token,
+        )
+        return flush_result
 
     def _ingest_batch_impl(
         self,
@@ -747,59 +814,65 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
                     f"Failed to get channel {channel_name}. Client may not be started."
                 )
 
+            # Insert rows into the channel with a single SDK batch append.
+            flush_result = None
             try:
-                latest_committed_offset_token = channel.get_latest_committed_offset_token()
-                logger.debug(
-                    "Latest committed offset for channel %s: %s",
-                    channel_name,
-                    latest_committed_offset_token,
-                )
+                offset_tokens = [
+                    self._offset_token_for_row(row, partition_id)
+                    for row in data_batch
+                ]
+                committed_before_append = channel.get_latest_committed_offset_token()
+                rows_to_append = [
+                    (row, offset_token)
+                    for row, offset_token in zip(data_batch, offset_tokens, strict=True)
+                    if not self._offset_token_reached(committed_before_append, offset_token)
+                ]
 
-                rows_to_append: list[dict[str, Any]] = []
-                offset_tokens: list[str] = []
-                rows_skipped = 0
-
-                for row_index, row in enumerate(data_batch):
-                    sequence_number = self._sequence_number_for_row(row, row_index)
-                    offset_token = self._offset_token_for_sequence(sequence_number)
-                    if self._is_committed(offset_token, latest_committed_offset_token):
-                        rows_skipped += 1
-                        continue
-
-                    rows_to_append.append(row)
-                    offset_tokens.append(offset_token)
-
+                # Snowflake channels store the latest committed offset token. On
+                # replay, skip rows at or below that token to avoid duplicate writes.
+                # See: https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-channels
                 if not rows_to_append:
                     logger.debug(
-                        "All %s rows for channel %s partition %s were already committed "
-                        "(latest offset token=%s)",
+                        "All %s rows for channel %s are already committed through offset token %s",
                         len(data_batch),
                         channel_name,
-                        partition_id,
-                        latest_committed_offset_token,
+                        committed_before_append,
                     )
-                    rows_inserted = 0
-                else:
-                    start_offset_token = offset_tokens[0]
-                    end_offset_token = offset_tokens[-1]
-
-                    self._append_rows(channel, rows_to_append, offset_tokens)
-
-                    rows_inserted = len(rows_to_append)
-                    logger.debug(
-                        "✅ Appended %s rows to channel %s (partition=%s, "
-                        "start_offset_token=%s, end_offset_token=%s, skipped=%s)",
-                        rows_inserted,
+                    self._maybe_check_channel_status(
                         channel_name,
-                        partition_id,
-                        start_offset_token,
-                        end_offset_token,
-                        rows_skipped,
+                        start_offset_token=offset_tokens[0],
+                        end_offset_token=offset_tokens[-1],
+                        force=True,
                     )
+                    return True
 
-                    self._wait_for_commit(channel, end_offset_token)
+                append_rows, append_offset_tokens = zip(*rows_to_append, strict=True)
+                self._append_rows_to_channel(
+                    channel,
+                    list(append_rows),
+                    list(append_offset_tokens),
+                )
+                rows_inserted = len(rows_to_append)
 
-                self._maybe_check_channel_status(channel_name)
+                logger.debug(
+                    f"Appended {rows_inserted} rows to channel {channel_name} (partition {partition_id})"
+                )
+
+                flush_result = self._wait_for_channel_commit(
+                    channel,
+                    channel_name,
+                    append_offset_tokens[-1],
+                )
+
+                offset_token = channel.get_latest_committed_offset_token()
+                logger.debug(f"Latest committed offset for channel {channel_name}: {offset_token}")
+
+                self._maybe_check_channel_status(
+                    channel_name,
+                    start_offset_token=append_offset_tokens[0],
+                    end_offset_token=append_offset_tokens[-1],
+                    force=True,
+                )
 
             except Exception as e:
                 if not _recovery_attempted and self._recover_streaming_state(channel_name, e):
@@ -834,30 +907,24 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
                 raise
 
             # Update statistics
-            if rows_inserted > 0:
-                self.stats["total_messages_sent"] += rows_inserted
-                self.stats["total_batches_sent"] += 1
-                self.stats["last_ingestion"] = datetime.now(UTC)
+            self.stats["total_messages_sent"] += rows_inserted
+            self.stats["total_batches_sent"] += 1
+            self.stats["last_ingestion"] = datetime.now(UTC)
 
             # Track ingestion metrics in span
             span.set_attribute("messages_sent", rows_inserted)
-            span.set_attribute("messages_skipped", rows_skipped)
+            span.set_attribute("source_messages", len(data_batch))
             span.set_attribute("total_messages", self.stats["total_messages_sent"])
             span.set_attribute("total_batches", self.stats["total_batches_sent"])
 
             logger.debug(
-                "Successfully ingested %s records to %s (partition %s, skipped %s)",
-                rows_inserted,
-                channel_name,
-                partition_id,
-                rows_skipped,
+                f"Successfully ingested {rows_inserted} records to {channel_name} (partition {partition_id})"
             )
             logfire.info(
                 "Batch ingested successfully",
                 channel=channel_name,
                 partition=partition_id,
                 records=rows_inserted,
-                skipped=rows_skipped,
                 total_messages=self.stats["total_messages_sent"],
             )
             return True

--- a/src/streaming/snowflake_high_performance.py
+++ b/src/streaming/snowflake_high_performance.py
@@ -11,7 +11,6 @@ Documentation: https://docs.snowflake.com/user-guide/snowpipe-streaming/snowpipe
 """
 
 import logging
-import re
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -209,6 +208,21 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
                 logfire.error("Failed to start Snowflake client", error=str(e))
                 self.stop()
                 raise
+
+    def _close_with_flush(self, closeable: Any) -> None:
+        """Close SDK objects while preserving flush semantics across SDK versions."""
+        close = getattr(closeable, "close", None)
+        if not callable(close):
+            return
+
+        try:
+            close(wait_for_flush=True)
+        except TypeError:
+            # Some Snowpipe Streaming SDK versions expose close(wait_for_flush=True),
+            # while older Python bindings only expose close(). The append path already
+            # waits for commits before checkpoints advance:
+            # https://docs.snowflake.com/en/user-guide/snowpipe-streaming-sdk-python/reference/latest/api/snowflake/ingest/streaming/index
+            close()
 
     def stop(self) -> None:
         """Stop the Snowflake streaming client and clean up resources."""
@@ -815,7 +829,6 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
                 )
 
             # Insert rows into the channel with a single SDK batch append.
-            flush_result = None
             try:
                 offset_tokens = [
                     self._offset_token_for_row(row, partition_id)
@@ -858,7 +871,7 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
                     f"Appended {rows_inserted} rows to channel {channel_name} (partition {partition_id})"
                 )
 
-                flush_result = self._wait_for_channel_commit(
+                self._wait_for_channel_commit(
                     channel,
                     channel_name,
                     append_offset_tokens[-1],

--- a/src/streaming/snowflake_high_performance.py
+++ b/src/streaming/snowflake_high_performance.py
@@ -367,8 +367,11 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
             return
 
         now = datetime.now(UTC)
-        if not force and self._last_channel_status_check_at is not None:
-            elapsed = (now - self._last_channel_status_check_at).total_seconds()
+        last_channel_status_check_at = self._last_channel_status_check_at_by_channel.get(
+            channel_name
+        )
+        if not force and last_channel_status_check_at is not None:
+            elapsed = (now - last_channel_status_check_at).total_seconds()
             if elapsed < interval:
                 return
 
@@ -400,6 +403,7 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
         self.stats["channel_status_checks"] += 1
         self.stats["last_channel_status_check"] = now
         self.stats["last_channel_status_code"] = status.status_code
+        self._last_channel_status_check_at_by_channel[channel_name] = now
 
         logger.info(
             "Channel status: name=%s status=%s rows_inserted=%s rows_parsed=%s rows_error=%s",
@@ -831,8 +835,7 @@ class SnowflakeHighPerformanceStreamingClient(SnowflakeStreamingClientBase):
             # Insert rows into the channel with a single SDK batch append.
             try:
                 offset_tokens = [
-                    self._offset_token_for_row(row, partition_id)
-                    for row in data_batch
+                    self._offset_token_for_row(row, partition_id) for row in data_batch
                 ]
                 committed_before_append = channel.get_latest_committed_offset_token()
                 rows_to_append = [

--- a/src/utils/azure_identity.py
+++ b/src/utils/azure_identity.py
@@ -7,7 +7,7 @@ authentication.
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
     from azure.identity.aio import AzureCliCredential, DefaultAzureCredential
@@ -97,4 +97,4 @@ async def build_eventhub_cli_credential(
         logger=logger,
         credential_mode="azure_cli",
     )
-    return credential, expires_on
+    return cast("AzureCliCredential", credential), expires_on

--- a/src/utils/azure_identity.py
+++ b/src/utils/azure_identity.py
@@ -1,51 +1,100 @@
 """
 Azure identity helpers for Event Hub clients.
 
-Provides a small helper to create and validate Azure CLI credentials with
+Provides a small helper to create and validate Azure credentials with
 predictable logging so we can see which identity is used during Event Hub
 authentication.
 """
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
-    from azure.identity.aio import AzureCliCredential
+    from azure.identity.aio import AzureCliCredential, DefaultAzureCredential
 else:  # Fallback for runtime without importing azure.identity during type checking
     AzureCliCredential = Any
+    DefaultAzureCredential = Any
+
+
+EVENTHUB_TOKEN_SCOPE = "https://eventhubs.azure.net/.default"
+EventHubCredentialMode = Literal["default", "azure_cli"]
+
+
+async def build_eventhub_credential(
+    namespace: str,
+    logger: logging.Logger,
+    *,
+    credential_mode: EventHubCredentialMode = "default",
+    managed_identity_client_id: str | None = None,
+) -> tuple["DefaultAzureCredential | AzureCliCredential", int, str]:
+    """Create an Azure credential and verify it can fetch an Event Hub token.
+
+    Args:
+        namespace: Event Hub namespace for logging context.
+        logger: Logger instance to emit diagnostic messages.
+        credential_mode: Credential strategy to use. Defaults to the production-capable
+            DefaultAzureCredential chain.
+        managed_identity_client_id: Optional user-assigned managed identity client ID.
+
+    Returns:
+        Tuple of (credential, token expiry epoch seconds, credential label).
+
+    Raises:
+        Exception: If credential creation or token retrieval fails.
+    """
+    # Import inside the function so unit tests can monkeypatch azure.identity.aio cleanly.
+    from azure.identity.aio import AzureCliCredential, DefaultAzureCredential
+
+    azure_identity_logger = logging.getLogger("azure.identity")
+    original_level = azure_identity_logger.level
+
+    credential: DefaultAzureCredential | AzureCliCredential | None = None
+
+    # Temporarily raise log level to see which credential in the chain is used.
+    azure_identity_logger.setLevel(logging.INFO)
+    try:
+        if credential_mode == "azure_cli":
+            # AzureCliCredential is deliberately an explicit dev opt-in because it shells
+            # out to local tooling; the Azure SDK docs describe it as a developer-tool
+            # credential. https://learn.microsoft.com/python/api/azure-identity/azure.identity.aio.azureclicredential
+            credential = AzureCliCredential()
+            credential_label = "AzureCliCredential"
+        else:
+            credential_kwargs: dict[str, str] = {}
+            if managed_identity_client_id:
+                credential_kwargs["managed_identity_client_id"] = managed_identity_client_id
+            # DefaultAzureCredential keeps the same code path for local dev, service
+            # principals, and managed identity. The managed_identity_client_id kwarg is
+            # the SDK-supported hook for user-assigned managed identities.
+            # https://learn.microsoft.com/python/api/azure-identity/azure.identity.aio.defaultazurecredential
+            credential = DefaultAzureCredential(**credential_kwargs)
+            credential_label = "DefaultAzureCredential"
+
+        logger.info("✅ %s created successfully for namespace %s", credential_label, namespace)
+
+        token = await credential.get_token(EVENTHUB_TOKEN_SCOPE)
+        logger.info("✅ Successfully obtained token for EventHub scope")
+        logger.info("Token expires at epoch: %s", token.expires_on)
+
+        return credential, token.expires_on, credential_label
+    except Exception:
+        if credential is not None:
+            try:
+                await credential.close()
+            except Exception:
+                logger.debug("Ignoring credential close failure after token validation error")
+        raise
+    finally:
+        azure_identity_logger.setLevel(original_level)
 
 
 async def build_eventhub_cli_credential(
     namespace: str, logger: logging.Logger
 ) -> tuple["AzureCliCredential", int]:
-    """Create an Azure CLI credential and verify it can fetch an Event Hub token.
-
-    Args:
-        namespace: Event Hub namespace for logging context.
-        logger: Logger instance to emit diagnostic messages.
-
-    Returns:
-        Tuple of (credential, token expiry epoch seconds).
-
-    Raises:
-        Exception: If credential creation or token retrieval fails.
-    """
-    # Import inside function so tests can monkeypatch azure.identity.aio.AzureCliCredential
-    from azure.identity.aio import AzureCliCredential
-
-    azure_identity_logger = logging.getLogger("azure.identity")
-    original_level = azure_identity_logger.level
-
-    # Temporarily raise log level to see which credential in the chain is used
-    azure_identity_logger.setLevel(logging.INFO)
-    try:
-        credential = AzureCliCredential()
-        logger.info("✅ AzureCliCredential created successfully")
-
-        token = await credential.get_token("https://eventhubs.azure.net/.default")
-        logger.info("✅ Successfully obtained token for EventHub scope")
-        logger.info("Token expires at epoch: %s", token.expires_on)
-
-        return credential, token.expires_on
-    finally:
-        azure_identity_logger.setLevel(original_level)
+    """Compatibility wrapper for callers that still explicitly request Azure CLI auth."""
+    credential, expires_on, _label = await build_eventhub_credential(
+        namespace=namespace,
+        logger=logger,
+        credential_mode="azure_cli",
+    )
+    return credential, expires_on

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -283,8 +283,8 @@ class EvSnowConfig(BaseSettings):
                     **data,
                     "namespace": self.eventhub_namespace,
                 }
-                self.event_hubs[f"EVENTHUBNAME_{hub_num}"] = EventHubConfig(
-                    **event_hub_kwargs,
+                self.event_hubs[f"EVENTHUBNAME_{hub_num}"] = EventHubConfig.model_validate(
+                    event_hub_kwargs
                 )
 
         # Parse Snowflake configurations

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -138,6 +138,14 @@ class EvSnowConfig(BaseSettings):
         validation_alias="USE_HYBRID_TABLE",
         description="Use Hybrid Table for control table (requires paid Snowflake account)",
     )
+    control_ownership_mode: Literal["durable", "local_single_consumer_smoke"] = Field(
+        default="durable",
+        validation_alias="CONTROL_OWNERSHIP_MODE",
+        description=(
+            "Partition ownership mode. durable uses the configured control backend; "
+            "local_single_consumer_smoke keeps ownership in memory and persists only checkpoints."
+        ),
+    )
     control_table_backend: Literal["snowflake", "postgres"] = Field(
         default="snowflake",
         validation_alias="CONTROL_TABLE_BACKEND",
@@ -371,9 +379,25 @@ class EvSnowConfig(BaseSettings):
             return v.strip().lower()
         return v
 
+    @field_validator("control_ownership_mode", mode="before")
+    @classmethod
+    def normalize_control_ownership_mode(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            return v.strip().lower()
+        return v
+
     @model_validator(mode="after")
     def validate_mappings_exist(self):
         """Validate that all mappings reference existing configurations."""
+        if (
+            self.control_ownership_mode == "local_single_consumer_smoke"
+            and self.control_table_backend != "snowflake"
+        ):
+            raise ValueError(
+                "CONTROL_OWNERSHIP_MODE=local_single_consumer_smoke is only valid with "
+                "CONTROL_TABLE_BACKEND=snowflake"
+            )
+
         for mapping in self.mappings:
             if mapping.event_hub_key not in self.event_hubs:
                 raise ValueError(

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -271,13 +271,6 @@ class EvSnowConfig(BaseSettings):
                     event_hub_data[hub_num] = {}
                 event_hub_data[hub_num][field_name] = value
 
-            match = event_hub_starting_position_pattern.match(key)
-            if match:
-                hub_num = match.group(1)
-                if hub_num not in event_hub_data:
-                    event_hub_data[hub_num] = {}
-                event_hub_data[hub_num]["starting_position_on_no_checkpoint"] = value
-
         # Create EventHubConfig instances with consumer groups
         for hub_num, data in event_hub_data.items():
             if "name" in data:  # Only create if we have a name

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -198,14 +198,51 @@ class EvSnowConfig(BaseSettings):
 
         # Parse Event Hub configurations
         event_hub_pattern = re.compile(r"^EVENTHUBNAME_(\d+)$")
-        event_hub_consumer_pattern = re.compile(r"^EVENTHUBNAME_(\d+)_CONSUMER_GROUP$")
-        event_hub_connection_pattern = re.compile(r"^EVENTHUBNAME_(\d+)_CONNECTION_STRING$")
-        event_hub_starting_position_pattern = re.compile(
-            r"^EVENTHUBNAME_(\d+)_STARTING_POSITION_ON_NO_CHECKPOINT$"
-        )
+        event_hub_option_pattern = re.compile(r"^EVENTHUBNAME_(\d+)_(.+)$")
+        event_hub_option_fields = {
+            "CONSUMER_GROUP": "consumer_group",
+            "CONNECTION_STRING": "connection_string",
+            "MAX_BATCH_SIZE": "max_batch_size",
+            "MAX_WAIT_TIME": "max_wait_time",
+            "PREFETCH_COUNT": "prefetch_count",
+            "RETRY_TOTAL": "retry_total",
+            "RETRY_BACKOFF_FACTOR": "retry_backoff_factor",
+            "RETRY_BACKOFF_MAX": "retry_backoff_max",
+            "RETRY_MODE": "retry_mode",
+            "LOAD_BALANCING_INTERVAL": "load_balancing_interval",
+            "PARTITION_OWNERSHIP_EXPIRATION_INTERVAL": "partition_ownership_expiration_interval",
+            "LOAD_BALANCING_STRATEGY": "load_balancing_strategy",
+            "TRACK_LAST_ENQUEUED_EVENT_PROPERTIES": "track_last_enqueued_event_properties",
+            "CREDENTIAL_MODE": "credential_mode",
+            "MANAGED_IDENTITY_CLIENT_ID": "managed_identity_client_id",
+            "STARTING_POSITION_ON_NO_CHECKPOINT": "starting_position_on_no_checkpoint",
+        }
+        event_hub_global_env = {
+            "EVENTHUB_CREDENTIAL_MODE": "credential_mode",
+            "EVENTHUB_MANAGED_IDENTITY_CLIENT_ID": "managed_identity_client_id",
+            "EVENTHUB_MAX_WAIT_TIME": "max_wait_time",
+            "EVENTHUB_PREFETCH_COUNT": "prefetch_count",
+            "EVENTHUB_RETRY_TOTAL": "retry_total",
+            "EVENTHUB_RETRY_BACKOFF_FACTOR": "retry_backoff_factor",
+            "EVENTHUB_RETRY_BACKOFF_MAX": "retry_backoff_max",
+            "EVENTHUB_RETRY_MODE": "retry_mode",
+            "EVENTHUB_LOAD_BALANCING_INTERVAL": "load_balancing_interval",
+            "EVENTHUB_PARTITION_OWNERSHIP_EXPIRATION_INTERVAL": (
+                "partition_ownership_expiration_interval"
+            ),
+            "EVENTHUB_LOAD_BALANCING_STRATEGY": "load_balancing_strategy",
+            "EVENTHUB_TRACK_LAST_ENQUEUED_EVENT_PROPERTIES": (
+                "track_last_enqueued_event_properties"
+            ),
+        }
 
         # First collect all Event Hub numbers and their consumer groups
-        event_hub_data: dict[str, dict[str, str]] = {}
+        event_hub_data: dict[str, dict[str, Any]] = {}
+        event_hub_defaults = {
+            field_name: env_vars[env_name]
+            for env_name, field_name in event_hub_global_env.items()
+            if env_vars.get(env_name) is not None
+        }
 
         for key, value in env_vars.items():
             match = event_hub_pattern.match(key)
@@ -215,19 +252,16 @@ class EvSnowConfig(BaseSettings):
                     event_hub_data[hub_num] = {}
                 event_hub_data[hub_num]["name"] = value
 
-            match = event_hub_consumer_pattern.match(key)
+            match = event_hub_option_pattern.match(key)
             if match:
                 hub_num = match.group(1)
+                option_name = match.group(2)
+                field_name = event_hub_option_fields.get(option_name)
+                if field_name is None:
+                    continue
                 if hub_num not in event_hub_data:
                     event_hub_data[hub_num] = {}
-                event_hub_data[hub_num]["consumer_group"] = value
-
-            match = event_hub_connection_pattern.match(key)
-            if match:
-                hub_num = match.group(1)
-                if hub_num not in event_hub_data:
-                    event_hub_data[hub_num] = {}
-                event_hub_data[hub_num]["connection_string"] = value
+                event_hub_data[hub_num][field_name] = value
 
             match = event_hub_starting_position_pattern.match(key)
             if match:
@@ -243,14 +277,13 @@ class EvSnowConfig(BaseSettings):
                     raise ValueError(
                         f"EVENTHUBNAME_{hub_num}_CONSUMER_GROUP is required for EVENTHUBNAME_{hub_num}"
                     )
+                event_hub_kwargs = {
+                    **event_hub_defaults,
+                    **data,
+                    "namespace": self.eventhub_namespace,
+                }
                 self.event_hubs[f"EVENTHUBNAME_{hub_num}"] = EventHubConfig(
-                    name=data["name"],
-                    namespace=self.eventhub_namespace,
-                    consumer_group=data["consumer_group"],
-                    connection_string=data.get("connection_string"),
-                    starting_position_on_no_checkpoint=data.get(
-                        "starting_position_on_no_checkpoint", "-1"
-                    ),
+                    **event_hub_kwargs,
                 )
 
         # Parse Snowflake configurations

--- a/src/utils/config_models/eventhub.py
+++ b/src/utils/config_models/eventhub.py
@@ -14,6 +14,11 @@ class EventHubConfig(BaseModel):
     connection_string: str | None = None
     consumer_group: str = Field(..., description="Consumer group name (required)")
 
+    @property
+    def use_connection_string(self) -> bool:
+        """Return whether this hub should authenticate with a connection string."""
+        return self.connection_string is not None
+
     max_batch_size: int = 1000
     max_wait_time: int = 60
     prefetch_count: int = 300

--- a/src/utils/config_models/eventhub.py
+++ b/src/utils/config_models/eventhub.py
@@ -1,8 +1,9 @@
 """Azure Event Hubs configuration models."""
 
 import re
+from typing import Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class EventHubConfig(BaseModel):
@@ -16,6 +17,25 @@ class EventHubConfig(BaseModel):
     max_batch_size: int = 1000
     max_wait_time: int = 60
     prefetch_count: int = 300
+    retry_total: int = 3
+    retry_backoff_factor: float = 0.8
+    retry_backoff_max: float = 120
+    retry_mode: Literal["exponential", "fixed"] = "exponential"
+    load_balancing_interval: float = 30
+    partition_ownership_expiration_interval: float | None = None
+    load_balancing_strategy: Literal["greedy", "balanced"] = "greedy"
+    track_last_enqueued_event_properties: bool = False
+    credential_mode: Literal["default", "azure_cli"] = Field(
+        default="default",
+        description=(
+            "Credential strategy for Entra ID auth. Use default for production-capable "
+            "DefaultAzureCredential; azure_cli is an explicit local-development opt-in."
+        ),
+    )
+    managed_identity_client_id: str | None = Field(
+        default=None,
+        description="Optional user-assigned managed identity client ID for DefaultAzureCredential.",
+    )
 
     checkpoint_interval_seconds: int = Field(
         default=300, description="Checkpoint interval (seconds)"
@@ -33,7 +53,7 @@ class EventHubConfig(BaseModel):
         default="-1",
         description=(
             "Starting position when no checkpoints exist. Options: '-1' (beginning), "
-            "'@latest' (only new), '0' (offset zero)"
+            "'@latest' (only new)"
         ),
     )
 
@@ -61,11 +81,76 @@ class EventHubConfig(BaseModel):
             raise ValueError("Consumer group cannot be empty")
         return v
 
+    @field_validator("credential_mode", "retry_mode", "load_balancing_strategy", mode="before")
+    @classmethod
+    def normalize_literal_fields(cls, v: str) -> str:
+        """Normalize case for enum-like config loaded from environment variables."""
+        if isinstance(v, str):
+            return v.strip().lower()
+        return v
+
+    @field_validator("managed_identity_client_id", mode="before")
+    @classmethod
+    def normalize_optional_string(cls, v: str | None) -> str | None:
+        """Treat blank optional strings from env files as unset."""
+        if isinstance(v, str):
+            cleaned = v.strip()
+            return cleaned or None
+        return v
+
+    @field_validator(
+        "max_batch_size",
+        "prefetch_count",
+        "retry_total",
+        "retry_backoff_factor",
+        "retry_backoff_max",
+        "load_balancing_interval",
+        "partition_ownership_expiration_interval",
+    )
+    @classmethod
+    def validate_positive_numbers(cls, v: float | int | None) -> float | int | None:
+        """Validate SDK tuning values before handing them to the Azure client."""
+        if v is not None and v <= 0:
+            raise ValueError("Event Hub numeric SDK settings must be greater than 0")
+        return v
+
+    @field_validator("max_wait_time")
+    @classmethod
+    def validate_max_wait_time(cls, v: int) -> int:
+        """Validate receive wait timeout.
+
+        Azure EventHubConsumerClient.receive documents max_wait_time=None or 0
+        as "wait until an event is received"; positive values call on_event
+        with None on idle intervals. We allow 0 to keep that SDK mode available.
+        https://learn.microsoft.com/python/api/azure-eventhub/azure.eventhub.eventhubconsumerclient
+        """
+        if v < 0:
+            raise ValueError("max_wait_time must be greater than or equal to 0")
+        return v
+
+    @model_validator(mode="after")
+    def validate_ownership_expiration_interval(self) -> "EventHubConfig":
+        """Validate Event Hubs load-balancing timing as one safety unit.
+
+        Azure's SDK default for partition_ownership_expiration_interval is six
+        times load_balancing_interval. Keeping custom values at least that wide
+        avoids expiring ownership between claim renewals under competing consumers.
+        https://learn.microsoft.com/python/api/azure-eventhub/azure.eventhub.eventhubconsumerclient
+        """
+        if self.partition_ownership_expiration_interval is not None:
+            minimum_expiration = self.load_balancing_interval * 6
+            if self.partition_ownership_expiration_interval < minimum_expiration:
+                raise ValueError(
+                    "partition_ownership_expiration_interval must be at least "
+                    "6 * load_balancing_interval"
+                )
+        return self
+
     @field_validator("starting_position_on_no_checkpoint")
     @classmethod
     def validate_starting_position(cls, v: str) -> str:
         """Validate starting position format."""
-        valid_positions = ["-1", "@latest", "0"]
+        valid_positions = ["-1", "@latest"]
         if v not in valid_positions:
             raise ValueError(
                 f"Invalid starting_position: {v}. Must be one of: {', '.join(valid_positions)}"

--- a/src/utils/postgres.py
+++ b/src/utils/postgres.py
@@ -1,6 +1,7 @@
 """Postgres utilities for control table storage."""
 
 import contextlib
+import hashlib
 import json
 import logging
 import time
@@ -30,6 +31,12 @@ def _checkpoint_value(waterlevel: Any, metadata: Any) -> dict[str, Any]:
 
 def _ownership_table_name(control_table: str) -> str:
     return f"{control_table}_ownership"
+
+
+def _advisory_lock_key(*parts: str) -> int:
+    lock_name = ".".join(parts)
+    digest = hashlib.blake2b(lock_name.encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(digest, byteorder="big", signed=True)
 
 
 def _get_cache_key(config: PostgresConnectionConfig, database: str) -> str:
@@ -311,34 +318,44 @@ def get_partition_checkpoints(
 
 
 def _ensure_postgres_ownership_table(cursor: Any, schema_name: str, table_name: str) -> None:
-    cursor.execute(
-        sql.SQL(
-            """
-            CREATE TABLE IF NOT EXISTS {}.{} (
-                fully_qualified_namespace TEXT NOT NULL,
-                eventhub_name TEXT NOT NULL,
-                consumer_group TEXT NOT NULL,
-                target_db TEXT NOT NULL,
-                target_schema TEXT NOT NULL,
-                target_table TEXT NOT NULL,
-                partition_id TEXT NOT NULL,
-                owner_id TEXT NOT NULL,
-                etag TEXT NOT NULL,
-                last_modified_time DOUBLE PRECISION NOT NULL,
-                ts_modified TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY (
-                    fully_qualified_namespace,
-                    eventhub_name,
-                    consumer_group,
-                    target_db,
-                    target_schema,
-                    target_table,
-                    partition_id
+    lock_key = _advisory_lock_key("evsnow", schema_name, table_name)
+    cursor.execute("SELECT pg_advisory_lock(%s)", (lock_key,))
+    try:
+        # Concurrent CREATE TABLE IF NOT EXISTS can still race on Postgres catalog
+        # rows (for example pg_type) when fresh consumers start together. A
+        # session advisory lock serializes only this lazy DDL path while keeping
+        # normal checkpoint writes unlocked.
+        # https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS
+        cursor.execute(
+            sql.SQL(
+                """
+                CREATE TABLE IF NOT EXISTS {}.{} (
+                    fully_qualified_namespace TEXT NOT NULL,
+                    eventhub_name TEXT NOT NULL,
+                    consumer_group TEXT NOT NULL,
+                    target_db TEXT NOT NULL,
+                    target_schema TEXT NOT NULL,
+                    target_table TEXT NOT NULL,
+                    partition_id TEXT NOT NULL,
+                    owner_id TEXT NOT NULL,
+                    etag TEXT NOT NULL,
+                    last_modified_time DOUBLE PRECISION NOT NULL,
+                    ts_modified TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (
+                        fully_qualified_namespace,
+                        eventhub_name,
+                        consumer_group,
+                        target_db,
+                        target_schema,
+                        target_table,
+                        partition_id
+                    )
                 )
-            )
-            """
-        ).format(sql.Identifier(schema_name), sql.Identifier(table_name))
-    )
+                """
+            ).format(sql.Identifier(schema_name), sql.Identifier(table_name))
+        )
+    finally:
+        cursor.execute("SELECT pg_advisory_unlock(%s)", (lock_key,))
 
 
 def list_partition_ownership(

--- a/src/utils/postgres.py
+++ b/src/utils/postgres.py
@@ -3,6 +3,8 @@
 import contextlib
 import json
 import logging
+import time
+import uuid
 from typing import Any
 
 import psycopg
@@ -17,6 +19,17 @@ _connection_cache: dict[str, psycopg.Connection] = {}
 _azure_credential: DefaultAzureCredential | None = None
 
 _AZURE_TOKEN_SCOPE = "https://ossrdbms-aad.database.windows.net/.default"
+
+
+def _checkpoint_value(waterlevel: Any, metadata: Any) -> dict[str, Any]:
+    decoded_metadata = metadata if isinstance(metadata, dict) else {}
+    sequence_number = decoded_metadata.get("sequence_number", waterlevel)
+    offset = decoded_metadata.get("offset_string", decoded_metadata.get("offset", waterlevel))
+    return {"offset": str(offset), "sequence_number": int(sequence_number)}
+
+
+def _ownership_table_name(control_table: str) -> str:
+    return f"{control_table}_ownership"
 
 
 def _get_cache_key(config: PostgresConnectionConfig, database: str) -> str:
@@ -256,7 +269,7 @@ def get_partition_checkpoints(
         cursor.execute(
             sql.SQL(
                 """
-                SELECT DISTINCT ON (partition_id) partition_id, waterlevel
+                SELECT DISTINCT ON (partition_id) partition_id, waterlevel, metadata
                 FROM {}.{}
                 WHERE eventhub_namespace = %s
                   AND eventhub = %s
@@ -284,7 +297,10 @@ def get_partition_checkpoints(
         logger.info("No partition checkpoints found for %s/%s", eventhub_namespace, eventhub)
         return None
 
-    partition_checkpoints = {row[0]: row[1] for row in results}
+    partition_checkpoints = {
+        row[0]: _checkpoint_value(row[1], row[2] if len(row) > 2 else None)
+        for row in results
+    }
     logger.info(
         "Retrieved partition checkpoints: %s for %s/%s",
         partition_checkpoints,
@@ -292,3 +308,198 @@ def get_partition_checkpoints(
         eventhub,
     )
     return partition_checkpoints
+
+
+def _ensure_postgres_ownership_table(cursor: Any, schema_name: str, table_name: str) -> None:
+    cursor.execute(
+        sql.SQL(
+            """
+            CREATE TABLE IF NOT EXISTS {}.{} (
+                fully_qualified_namespace TEXT NOT NULL,
+                eventhub_name TEXT NOT NULL,
+                consumer_group TEXT NOT NULL,
+                target_db TEXT NOT NULL,
+                target_schema TEXT NOT NULL,
+                target_table TEXT NOT NULL,
+                partition_id TEXT NOT NULL,
+                owner_id TEXT NOT NULL,
+                etag TEXT NOT NULL,
+                last_modified_time DOUBLE PRECISION NOT NULL,
+                ts_modified TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (
+                    fully_qualified_namespace,
+                    eventhub_name,
+                    consumer_group,
+                    target_db,
+                    target_schema,
+                    target_table,
+                    partition_id
+                )
+            )
+            """
+        ).format(sql.Identifier(schema_name), sql.Identifier(table_name))
+    )
+
+
+def list_partition_ownership(
+    fully_qualified_namespace: str,
+    eventhub_name: str,
+    consumer_group: str,
+    target_db: str,
+    target_schema: str,
+    target_table: str,
+    config: PostgresConnectionConfig | None = None,
+    control_db: str | None = None,
+    control_schema: str | None = None,
+    control_table: str | None = None,
+) -> list[dict[str, Any]]:
+    if config is None:
+        config = PostgresConnectionConfig()
+
+    actual_control_db = control_db or target_db
+    actual_control_schema = control_schema or target_schema
+    ownership_table = _ownership_table_name(control_table or "INGESTION_STATUS")
+
+    conn = get_connection(config, actual_control_db, use_cache=True)
+    with conn.cursor() as cursor:
+        _ensure_postgres_ownership_table(cursor, actual_control_schema, ownership_table)
+        cursor.execute(
+            sql.SQL(
+                """
+                SELECT partition_id, owner_id, etag, last_modified_time
+                FROM {}.{}
+                WHERE fully_qualified_namespace = %s
+                  AND eventhub_name = %s
+                  AND consumer_group = %s
+                  AND target_db = %s
+                  AND target_schema = %s
+                  AND target_table = %s
+                """
+            ).format(
+                sql.Identifier(actual_control_schema),
+                sql.Identifier(ownership_table),
+            ),
+            (
+                fully_qualified_namespace,
+                eventhub_name,
+                consumer_group,
+                target_db,
+                target_schema,
+                target_table,
+            ),
+        )
+        rows = cursor.fetchall()
+
+    return [
+        {
+            "fully_qualified_namespace": fully_qualified_namespace,
+            "eventhub_name": eventhub_name,
+            "consumer_group": consumer_group,
+            "partition_id": row[0],
+            "owner_id": row[1],
+            "etag": row[2],
+            "last_modified_time": float(row[3]),
+        }
+        for row in rows
+    ]
+
+
+def claim_partition_ownership(
+    ownership_list: list[dict[str, Any]],
+    target_db: str,
+    target_schema: str,
+    target_table: str,
+    config: PostgresConnectionConfig | None = None,
+    control_db: str | None = None,
+    control_schema: str | None = None,
+    control_table: str | None = None,
+) -> list[dict[str, Any]]:
+    if not ownership_list:
+        return []
+
+    if config is None:
+        config = PostgresConnectionConfig()
+
+    actual_control_db = control_db or target_db
+    actual_control_schema = control_schema or target_schema
+    ownership_table = _ownership_table_name(control_table or "INGESTION_STATUS")
+
+    conn = get_connection(config, actual_control_db, use_cache=True)
+    claimed: list[dict[str, Any]] = []
+    with conn.cursor() as cursor:
+        _ensure_postgres_ownership_table(cursor, actual_control_schema, ownership_table)
+        for ownership in ownership_list:
+            now = time.time()
+            new_etag = uuid.uuid4().hex
+            if ownership.get("etag"):
+                cursor.execute(
+                    sql.SQL(
+                        """
+                        UPDATE {}.{}
+                        SET owner_id = %s,
+                            etag = %s,
+                            last_modified_time = %s,
+                            ts_modified = CURRENT_TIMESTAMP
+                        WHERE fully_qualified_namespace = %s
+                          AND eventhub_name = %s
+                          AND consumer_group = %s
+                          AND target_db = %s
+                          AND target_schema = %s
+                          AND target_table = %s
+                          AND partition_id = %s
+                          AND etag = %s
+                        RETURNING partition_id
+                        """
+                    ).format(
+                        sql.Identifier(actual_control_schema),
+                        sql.Identifier(ownership_table),
+                    ),
+                    (
+                        ownership["owner_id"],
+                        new_etag,
+                        now,
+                        ownership["fully_qualified_namespace"],
+                        ownership["eventhub_name"],
+                        ownership["consumer_group"],
+                        target_db,
+                        target_schema,
+                        target_table,
+                        ownership["partition_id"],
+                        ownership["etag"],
+                    ),
+                )
+            else:
+                cursor.execute(
+                    sql.SQL(
+                        """
+                        INSERT INTO {}.{} (
+                            fully_qualified_namespace, eventhub_name, consumer_group,
+                            target_db, target_schema, target_table, partition_id,
+                            owner_id, etag, last_modified_time, ts_modified
+                        )
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, CURRENT_TIMESTAMP)
+                        ON CONFLICT DO NOTHING
+                        RETURNING partition_id
+                        """
+                    ).format(
+                        sql.Identifier(actual_control_schema),
+                        sql.Identifier(ownership_table),
+                    ),
+                    (
+                        ownership["fully_qualified_namespace"],
+                        ownership["eventhub_name"],
+                        ownership["consumer_group"],
+                        target_db,
+                        target_schema,
+                        target_table,
+                        ownership["partition_id"],
+                        ownership["owner_id"],
+                        new_etag,
+                        now,
+                    ),
+                )
+
+            if cursor.fetchone():
+                claimed.append({**ownership, "etag": new_etag, "last_modified_time": now})
+
+    return claimed

--- a/src/utils/postgres.py
+++ b/src/utils/postgres.py
@@ -263,7 +263,7 @@ def get_partition_checkpoints(
     control_db: str | None = None,
     control_schema: str | None = None,
     control_table: str | None = None,
-) -> dict[str, int] | None:
+) -> dict[str, dict[str, Any]] | None:
     if config is None:
         config = PostgresConnectionConfig()
 
@@ -305,8 +305,7 @@ def get_partition_checkpoints(
         return None
 
     partition_checkpoints = {
-        row[0]: _checkpoint_value(row[1], row[2] if len(row) > 2 else None)
-        for row in results
+        row[0]: _checkpoint_value(row[1], row[2] if len(row) > 2 else None) for row in results
     }
     logger.info(
         "Retrieved partition checkpoints: %s for %s/%s",

--- a/src/utils/snowflake.py
+++ b/src/utils/snowflake.py
@@ -15,6 +15,8 @@ import json
 import logging
 import os
 import tempfile
+import time
+import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -31,6 +33,41 @@ logger = logging.getLogger(__name__)
 # Connection cache for reusing connections in high-performance streaming scenarios
 # Key: (account, user, database, schema, warehouse, role)
 _connection_cache: dict[tuple, sc.SnowflakeConnection] = {}
+
+
+def _decode_checkpoint_metadata(metadata: Any) -> dict[str, Any]:
+    if metadata is None:
+        return {}
+    if isinstance(metadata, dict):
+        return metadata
+    if isinstance(metadata, str):
+        try:
+            return json.loads(metadata)
+        except json.JSONDecodeError:
+            return {}
+    if hasattr(metadata, "as_py"):
+        value = metadata.as_py()
+        return value if isinstance(value, dict) else {}
+    return {}
+
+
+def _checkpoint_value(waterlevel: Any, metadata: Any) -> dict[str, Any]:
+    decoded_metadata = _decode_checkpoint_metadata(metadata)
+    sequence_number = decoded_metadata.get("sequence_number", waterlevel)
+    offset = decoded_metadata.get("offset_string", decoded_metadata.get("offset", waterlevel))
+    return {"offset": str(offset), "sequence_number": int(sequence_number)}
+
+
+def _ownership_table_name(control_table: str) -> str:
+    return f"{control_table}_OWNERSHIP"
+
+
+def _validate_snowflake_identifiers(identifiers: list[str]) -> None:
+    import re
+
+    for identifier in identifiers:
+        if not re.match(r"^[A-Za-z0-9_$]+$", identifier):
+            raise ValueError(f"Invalid Snowflake identifier: {identifier}")
 
 
 @contextmanager
@@ -622,7 +659,7 @@ def get_partition_checkpoints(
                 logger.debug(f"Activated warehouse: {config.warehouse}")
 
             sql = f"""
-                SELECT PARTITION_ID, WATERLEVEL
+                SELECT PARTITION_ID, WATERLEVEL, METADATA
                 FROM {control_table_fqn}
                 WHERE EVENTHUB_NAMESPACE = %s
                   AND EVENTHUB = %s
@@ -654,7 +691,10 @@ def get_partition_checkpoints(
             logger.info(f"No partition checkpoints found for {eventhub_namespace}/{eventhub}")
             return None
 
-        partition_checkpoints = {row[0]: row[1] for row in results}
+        partition_checkpoints = {
+            row[0]: _checkpoint_value(row[1], row[2] if len(row) > 2 else None)
+            for row in results
+        }
 
         logger.info(
             f"Retrieved partition checkpoints: {partition_checkpoints} for {eventhub_namespace}/{eventhub}"
@@ -666,6 +706,252 @@ def get_partition_checkpoints(
         logger.error(f"  EventHub: {eventhub_namespace}/{eventhub}")
         logger.error(f"  Control Table: {target_db}.{target_schema}.{target_table}")
         raise
+
+
+def _ensure_snowflake_ownership_table(cursor: Any, ownership_table_fqn: str) -> None:
+    database_name, schema_name, table_name = ownership_table_fqn.split(".", maxsplit=2)
+
+    cursor.execute(f"SHOW HYBRID TABLES LIKE '{table_name}' IN SCHEMA {database_name}.{schema_name}")
+    if cursor.fetchall():
+        return
+
+    cursor.execute(f"SHOW TABLES LIKE '{table_name}' IN SCHEMA {database_name}.{schema_name}")
+    if cursor.fetchall():
+        raise RuntimeError(
+            f"Existing Snowflake ownership table {ownership_table_fqn} is not a Hybrid Table. "
+            "Migrate or drop it before enabling multi-consumer Event Hub ownership."
+        )
+
+    # Snowflake standard-table unique constraints are not enforced; ownership
+    # claims need a Hybrid Table primary key for real compare-and-set behavior.
+    # See: https://docs.snowflake.com/en/sql-reference/constraints-overview
+    cursor.execute(
+        f"""
+        CREATE HYBRID TABLE IF NOT EXISTS {ownership_table_fqn} (
+            FULLY_QUALIFIED_NAMESPACE VARCHAR(500) NOT NULL,
+            EVENTHUB_NAME VARCHAR(500) NOT NULL,
+            CONSUMER_GROUP VARCHAR(200) NOT NULL,
+            TARGET_DB VARCHAR(200) NOT NULL,
+            TARGET_SCHEMA VARCHAR(200) NOT NULL,
+            TARGET_TABLE VARCHAR(200) NOT NULL,
+            PARTITION_ID VARCHAR(50) NOT NULL,
+            OWNER_ID VARCHAR(500) NOT NULL,
+            ETAG VARCHAR(100) NOT NULL,
+            LAST_MODIFIED_TIME FLOAT NOT NULL,
+            TS_MODIFIED TIMESTAMP_NTZ NOT NULL,
+            PRIMARY KEY (
+                FULLY_QUALIFIED_NAMESPACE,
+                EVENTHUB_NAME,
+                CONSUMER_GROUP,
+                TARGET_DB,
+                TARGET_SCHEMA,
+                TARGET_TABLE,
+                PARTITION_ID
+            )
+        )
+        """
+    )
+
+
+def list_partition_ownership(
+    fully_qualified_namespace: str,
+    eventhub_name: str,
+    consumer_group: str,
+    target_db: str,
+    target_schema: str,
+    target_table: str,
+    config: SnowflakeConnectionConfig | None = None,
+    control_db: str | None = None,
+    control_schema: str | None = None,
+    control_table: str | None = None,
+) -> list[dict[str, Any]]:
+    if config is None:
+        config = SnowflakeConnectionConfig()
+
+    actual_control_db = control_db or config.database
+    actual_control_schema = control_schema or config.schema_name
+    actual_control_table = control_table or "INGESTION_STATUS"
+    ownership_table = _ownership_table_name(actual_control_table)
+
+    identifiers = [
+        actual_control_db,
+        actual_control_schema,
+        ownership_table,
+        target_db,
+        target_schema,
+        target_table,
+    ]
+    if config.warehouse:
+        identifiers.append(config.warehouse)
+    _validate_snowflake_identifiers(identifiers)
+
+    ownership_table_fqn = f"{actual_control_db}.{actual_control_schema}.{ownership_table}"
+    conn = get_connection(config, use_cache=True)
+    cursor = conn.cursor()
+    try:
+        if config.warehouse:
+            cursor.execute(f"USE WAREHOUSE {config.warehouse}")
+        _ensure_snowflake_ownership_table(cursor, ownership_table_fqn)
+        cursor.execute(
+            f"""
+            SELECT PARTITION_ID, OWNER_ID, ETAG, LAST_MODIFIED_TIME
+            FROM {ownership_table_fqn}
+            WHERE FULLY_QUALIFIED_NAMESPACE = %s
+              AND EVENTHUB_NAME = %s
+              AND CONSUMER_GROUP = %s
+              AND TARGET_DB = %s
+              AND TARGET_SCHEMA = %s
+              AND TARGET_TABLE = %s
+            """,
+            (
+                fully_qualified_namespace,
+                eventhub_name,
+                consumer_group,
+                target_db,
+                target_schema,
+                target_table,
+            ),
+        )
+        rows = cursor.fetchall()
+    finally:
+        cursor.close()
+
+    return [
+        {
+            "fully_qualified_namespace": fully_qualified_namespace,
+            "eventhub_name": eventhub_name,
+            "consumer_group": consumer_group,
+            "partition_id": row[0],
+            "owner_id": row[1],
+            "etag": row[2],
+            "last_modified_time": float(row[3]),
+        }
+        for row in rows
+    ]
+
+
+def claim_partition_ownership(
+    ownership_list: list[dict[str, Any]],
+    target_db: str,
+    target_schema: str,
+    target_table: str,
+    config: SnowflakeConnectionConfig | None = None,
+    control_db: str | None = None,
+    control_schema: str | None = None,
+    control_table: str | None = None,
+) -> list[dict[str, Any]]:
+    if not ownership_list:
+        return []
+
+    if config is None:
+        config = SnowflakeConnectionConfig()
+
+    actual_control_db = control_db or config.database
+    actual_control_schema = control_schema or config.schema_name
+    actual_control_table = control_table or "INGESTION_STATUS"
+    ownership_table = _ownership_table_name(actual_control_table)
+    ownership_table_fqn = f"{actual_control_db}.{actual_control_schema}.{ownership_table}"
+
+    identifiers = [
+            actual_control_db,
+            actual_control_schema,
+            ownership_table,
+            target_db,
+            target_schema,
+            target_table,
+    ]
+    if config.warehouse:
+        identifiers.append(config.warehouse)
+    _validate_snowflake_identifiers(identifiers)
+
+    conn = get_connection(config, use_cache=True)
+    cursor = conn.cursor()
+    claimed: list[dict[str, Any]] = []
+    try:
+        if config.warehouse:
+            cursor.execute(f"USE WAREHOUSE {config.warehouse}")
+        _ensure_snowflake_ownership_table(cursor, ownership_table_fqn)
+
+        for ownership in ownership_list:
+            now = time.time()
+            new_etag = uuid.uuid4().hex
+            base_values = (
+                ownership["fully_qualified_namespace"],
+                ownership["eventhub_name"],
+                ownership["consumer_group"],
+                target_db,
+                target_schema,
+                target_table,
+                ownership["partition_id"],
+                ownership["owner_id"],
+                new_etag,
+                now,
+            )
+
+            try:
+                if ownership.get("etag"):
+                    cursor.execute(
+                        f"""
+                        UPDATE {ownership_table_fqn}
+                        SET OWNER_ID = %s,
+                            ETAG = %s,
+                            LAST_MODIFIED_TIME = %s,
+                            TS_MODIFIED = CURRENT_TIMESTAMP()
+                        WHERE FULLY_QUALIFIED_NAMESPACE = %s
+                          AND EVENTHUB_NAME = %s
+                          AND CONSUMER_GROUP = %s
+                          AND TARGET_DB = %s
+                          AND TARGET_SCHEMA = %s
+                          AND TARGET_TABLE = %s
+                          AND PARTITION_ID = %s
+                          AND ETAG = %s
+                        """,
+                        (
+                            ownership["owner_id"],
+                            new_etag,
+                            now,
+                            ownership["fully_qualified_namespace"],
+                            ownership["eventhub_name"],
+                            ownership["consumer_group"],
+                            target_db,
+                            target_schema,
+                            target_table,
+                            ownership["partition_id"],
+                            ownership["etag"],
+                        ),
+                    )
+                else:
+                    cursor.execute(
+                        f"""
+                        INSERT INTO {ownership_table_fqn} (
+                            FULLY_QUALIFIED_NAMESPACE, EVENTHUB_NAME, CONSUMER_GROUP,
+                            TARGET_DB, TARGET_SCHEMA, TARGET_TABLE, PARTITION_ID,
+                            OWNER_ID, ETAG, LAST_MODIFIED_TIME, TS_MODIFIED
+                        )
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, CURRENT_TIMESTAMP())
+                        """,
+                        base_values,
+                    )
+            except Exception as exc:
+                logger.info(
+                    "Ownership claim skipped for partition %s: %s",
+                    ownership.get("partition_id"),
+                    exc,
+                )
+                continue
+
+            if getattr(cursor, "rowcount", 0) == 1:
+                claimed.append(
+                    {
+                        **ownership,
+                        "etag": new_etag,
+                        "last_modified_time": now,
+                    }
+                )
+    finally:
+        cursor.close()
+
+    return claimed
 
 
 # Example usage

--- a/src/utils/snowflake.py
+++ b/src/utils/snowflake.py
@@ -597,7 +597,7 @@ def get_partition_checkpoints(
     control_db: str | None = None,
     control_schema: str | None = None,
     control_table: str | None = None,
-) -> dict[str, int] | None:
+) -> dict[str, dict[str, Any]] | None:
     """
     Retrieve the latest checkpoint for each partition.
 
@@ -613,7 +613,7 @@ def get_partition_checkpoints(
         control_table: Control table name (default: INGESTION_STATUS)
 
     Returns:
-        Dictionary mapping partition_id to waterlevel, or None if no checkpoints found
+        Dictionary mapping partition_id to checkpoint metadata, or None if no checkpoints found
 
     Raises:
         Exception: If query fails
@@ -692,8 +692,7 @@ def get_partition_checkpoints(
             return None
 
         partition_checkpoints = {
-            row[0]: _checkpoint_value(row[1], row[2] if len(row) > 2 else None)
-            for row in results
+            row[0]: _checkpoint_value(row[1], row[2] if len(row) > 2 else None) for row in results
         }
 
         logger.info(
@@ -711,7 +710,9 @@ def get_partition_checkpoints(
 def _ensure_snowflake_ownership_table(cursor: Any, ownership_table_fqn: str) -> None:
     database_name, schema_name, table_name = ownership_table_fqn.split(".", maxsplit=2)
 
-    cursor.execute(f"SHOW HYBRID TABLES LIKE '{table_name}' IN SCHEMA {database_name}.{schema_name}")
+    cursor.execute(
+        f"SHOW HYBRID TABLES LIKE '{table_name}' IN SCHEMA {database_name}.{schema_name}"
+    )
     if cursor.fetchall():
         return
 
@@ -853,12 +854,12 @@ def claim_partition_ownership(
     ownership_table_fqn = f"{actual_control_db}.{actual_control_schema}.{ownership_table}"
 
     identifiers = [
-            actual_control_db,
-            actual_control_schema,
-            ownership_table,
-            target_db,
-            target_schema,
-            target_table,
+        actual_control_db,
+        actual_control_schema,
+        ownership_table,
+        target_db,
+        target_schema,
+        target_table,
     ]
     if config.warehouse:
         identifiers.append(config.warehouse)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,7 +300,10 @@ def mock_snowflake_streaming_client(mocker):
     """Mock Snowflake StreamingIngestClient (high-performance SDK)."""
     mock_client = mocker.MagicMock()
     mock_channel = mocker.MagicMock()
+    mock_channel.append_rows.return_value = None
     mock_channel.append_row.return_value = None
+    mock_channel.initiate_flush.return_value = None
+    mock_channel.wait_for_commit.return_value = None
     mock_channel.get_latest_committed_offset_token.return_value = "12345"
     mock_channel.close.return_value = None
 

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -150,23 +150,25 @@ class TestEndToEndPipeline:
 
         # Assert: Verify Snowflake ingestion
         assert success is True
-        assert len(ingested_batches) == 3
+        expected_partitions = {message.partition_id for message in sample_eventhub_messages}
+        assert {batch["partition"] for batch in ingested_batches} == expected_partitions
+        assert len(ingested_batches) == len(expected_partitions)
 
-        assert [batch["partition"] for batch in ingested_batches] == ["0", "1", "2"]
-        assert [batch["channel"] for batch in ingested_batches] == [
-            f"{mapping.channel_name}-p0",
-            f"{mapping.channel_name}-p1",
-            f"{mapping.channel_name}-p2",
-        ]
+        total_ingested_messages = sum(len(batch["data"]) for batch in ingested_batches)
+        assert total_ingested_messages == len(sample_eventhub_messages)
 
         # Verify data format
-        data_items = [data_item for batch in ingested_batches for data_item in batch["data"]]
-        assert len(data_items) == len(sample_eventhub_messages)
-        for data_item in data_items:
-            assert "event_body" in data_item
-            assert "partition_id" in data_item
-            assert "sequence_number" in data_item
-            assert "ingestion_timestamp" in data_item
+        for batch in ingested_batches:
+            assert "channel" in batch
+            assert "data" in batch
+            assert "partition" in batch
+            assert batch["channel"].endswith(f"-p-{batch['partition']}")
+            assert all(item["partition_id"] == batch["partition"] for item in batch["data"])
+            for data_item in batch["data"]:
+                assert "event_body" in data_item
+                assert "partition_id" in data_item
+                assert "sequence_number" in data_item
+                assert "ingestion_timestamp" in data_item
 
     async def test_pipeline_stats_tracked_correctly(
         self,
@@ -615,14 +617,14 @@ class TestErrorRecovery:
             message.partition_id = "0"
 
         # Manually retry the ingestion
+        single_partition_messages = [
+            message for message in sample_eventhub_messages if message.partition_id == "0"
+        ]
         success = False
         for _ in range(3):
-            try:
-                success = mapping._process_messages(sample_eventhub_messages)
-                if success:
-                    break
-            except ConnectionError:
-                continue
+            success = mapping._process_messages(single_partition_messages)
+            if success:
+                break
 
         # Cleanup
         mapping.snowflake_client.stop()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -512,9 +512,82 @@ class TestEventHubConfig:
         assert config.max_batch_size == 1000
         assert config.max_wait_time == 60
         assert config.prefetch_count == 300
+        assert config.retry_total == 3
+        assert config.retry_backoff_factor == 0.8
+        assert config.retry_backoff_max == 120
+        assert config.retry_mode == "exponential"
+        assert config.load_balancing_interval == 30
+        assert config.partition_ownership_expiration_interval is None
+        assert config.load_balancing_strategy == "greedy"
+        assert config.track_last_enqueued_event_properties is False
+        assert config.credential_mode == "default"
+        assert config.managed_identity_client_id is None
         assert config.checkpoint_interval_seconds == 300
         assert config.max_message_batch_size == 1000
         assert config.batch_timeout_seconds == 300
+
+    def test_eventhub_sdk_settings_validate_positive_numbers(self):
+        """Test invalid Azure SDK numeric settings are rejected early."""
+        with pytest.raises(ValidationError) as exc_info:
+            EventHubConfig(
+                name="test-hub",
+                namespace="test.servicebus.windows.net",
+                consumer_group="$Default",
+                retry_total=0,
+            )
+
+        assert "greater than 0" in str(exc_info.value)
+
+    def test_eventhub_max_wait_time_allows_zero(self):
+        """Test Azure's documented wait-until-event mode is allowed."""
+        config = EventHubConfig(
+            name="test-hub",
+            namespace="test.servicebus.windows.net",
+            consumer_group="$Default",
+            max_wait_time=0,
+        )
+
+        assert config.max_wait_time == 0
+
+    def test_eventhub_max_wait_time_rejects_negative_values(self):
+        """Test negative receive wait timeout is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            EventHubConfig(
+                name="test-hub",
+                namespace="test.servicebus.windows.net",
+                consumer_group="$Default",
+                max_wait_time=-1,
+            )
+
+        assert "greater than or equal to 0" in str(exc_info.value)
+
+    def test_eventhub_ownership_expiration_must_cover_load_balancing_interval(self):
+        """Test ownership expiration cannot be shorter than Azure's safe renewal window."""
+        with pytest.raises(ValidationError) as exc_info:
+            EventHubConfig(
+                name="test-hub",
+                namespace="test.servicebus.windows.net",
+                consumer_group="$Default",
+                load_balancing_interval=30,
+                partition_ownership_expiration_interval=60,
+            )
+
+        assert "6 * load_balancing_interval" in str(exc_info.value)
+
+    def test_eventhub_literal_settings_normalize_case(self):
+        """Test enum-like Event Hub settings accept env-style uppercase values."""
+        config = EventHubConfig(
+            name="test-hub",
+            namespace="test.servicebus.windows.net",
+            consumer_group="$Default",
+            credential_mode="AZURE_CLI",
+            retry_mode="FIXED",
+            load_balancing_strategy="BALANCED",
+        )
+
+        assert config.credential_mode == "azure_cli"
+        assert config.retry_mode == "fixed"
+        assert config.load_balancing_strategy == "balanced"
 
     def test_validate_starting_position_invalid(self):
         """Test that invalid starting positions are rejected."""
@@ -527,6 +600,28 @@ class TestEventHubConfig:
             )
 
         assert "Invalid starting_position" in str(exc_info.value)
+
+    def test_validate_starting_position_rejects_offset_zero(self):
+        """Test offset '0' is rejected because '-1' is the safe beginning option."""
+        with pytest.raises(ValidationError) as exc_info:
+            EventHubConfig(
+                name="test-hub",
+                namespace="test.servicebus.windows.net",
+                consumer_group="$Default",
+                starting_position_on_no_checkpoint="0",
+            )
+
+        assert "Invalid starting_position" in str(exc_info.value)
+
+    def test_use_connection_string_default(self):
+        """Test that use_connection_string defaults to False."""
+        config = EventHubConfig(
+            name="test-hub",
+            namespace="test.servicebus.windows.net",
+            consumer_group="$Default",
+        )
+
+        assert config.use_connection_string is False
 
     def test_connection_string_optional(self):
         """Test that connection string is optional."""
@@ -1043,3 +1138,63 @@ class TestLoadConfig:
 
         assert config.environment == "development"
         assert config.region == "default"
+
+    def test_load_config_parses_eventhub_sdk_options_from_env(self, monkeypatch):
+        """Test dynamic Event Hub SDK options are parsed into EventHubConfig."""
+        monkeypatch.setenv("EVENTHUB_NAMESPACE", "test.servicebus.windows.net")
+        monkeypatch.setenv("EVENTHUBNAME_1", "hub1")
+        monkeypatch.setenv("EVENTHUBNAME_1_CONSUMER_GROUP", "group1")
+        monkeypatch.setenv("EVENTHUBNAME_1_MAX_WAIT_TIME", "15")
+        monkeypatch.setenv("EVENTHUBNAME_1_PREFETCH_COUNT", "75")
+        monkeypatch.setenv("EVENTHUBNAME_1_RETRY_TOTAL", "7")
+        monkeypatch.setenv("EVENTHUBNAME_1_RETRY_BACKOFF_FACTOR", "1.5")
+        monkeypatch.setenv("EVENTHUBNAME_1_RETRY_BACKOFF_MAX", "30")
+        monkeypatch.setenv("EVENTHUBNAME_1_RETRY_MODE", "fixed")
+        monkeypatch.setenv("EVENTHUBNAME_1_LOAD_BALANCING_INTERVAL", "12")
+        monkeypatch.setenv("EVENTHUBNAME_1_PARTITION_OWNERSHIP_EXPIRATION_INTERVAL", "90")
+        monkeypatch.setenv("EVENTHUBNAME_1_LOAD_BALANCING_STRATEGY", "balanced")
+        monkeypatch.setenv("EVENTHUBNAME_1_TRACK_LAST_ENQUEUED_EVENT_PROPERTIES", "true")
+        monkeypatch.setenv("EVENTHUBNAME_1_CREDENTIAL_MODE", "azure_cli")
+        monkeypatch.setenv("EVENTHUBNAME_1_MANAGED_IDENTITY_CLIENT_ID", "client-id")
+        monkeypatch.setenv("EVENTHUBNAME_1_STARTING_POSITION_ON_NO_CHECKPOINT", "@latest")
+
+        config = load_config()
+        hub = config.event_hubs["EVENTHUBNAME_1"]
+
+        assert hub.max_wait_time == 15
+        assert hub.prefetch_count == 75
+        assert hub.retry_total == 7
+        assert hub.retry_backoff_factor == 1.5
+        assert hub.retry_backoff_max == 30
+        assert hub.retry_mode == "fixed"
+        assert hub.load_balancing_interval == 12
+        assert hub.partition_ownership_expiration_interval == 90
+        assert hub.load_balancing_strategy == "balanced"
+        assert hub.track_last_enqueued_event_properties is True
+        assert hub.credential_mode == "azure_cli"
+        assert hub.managed_identity_client_id == "client-id"
+        assert hub.starting_position_on_no_checkpoint == "@latest"
+
+    def test_load_config_applies_global_eventhub_defaults(self, monkeypatch):
+        """Test global Event Hub defaults apply unless a hub overrides them."""
+        monkeypatch.setenv("EVENTHUB_NAMESPACE", "test.servicebus.windows.net")
+        monkeypatch.setenv("EVENTHUB_CREDENTIAL_MODE", "azure_cli")
+        monkeypatch.setenv("EVENTHUB_MAX_WAIT_TIME", "10")
+        monkeypatch.setenv("EVENTHUB_PREFETCH_COUNT", "60")
+        monkeypatch.setenv("EVENTHUB_RETRY_TOTAL", "5")
+        monkeypatch.setenv("EVENTHUBNAME_1", "hub1")
+        monkeypatch.setenv("EVENTHUBNAME_1_CONSUMER_GROUP", "group1")
+        monkeypatch.setenv("EVENTHUBNAME_2", "hub2")
+        monkeypatch.setenv("EVENTHUBNAME_2_CONSUMER_GROUP", "group2")
+        monkeypatch.setenv("EVENTHUBNAME_2_RETRY_TOTAL", "9")
+
+        config = load_config()
+
+        assert config.event_hubs["EVENTHUBNAME_1"].credential_mode == "azure_cli"
+        assert config.event_hubs["EVENTHUBNAME_1"].max_wait_time == 10
+        assert config.event_hubs["EVENTHUBNAME_1"].prefetch_count == 60
+        assert config.event_hubs["EVENTHUBNAME_1"].retry_total == 5
+        assert config.event_hubs["EVENTHUBNAME_2"].credential_mode == "azure_cli"
+        assert config.event_hubs["EVENTHUBNAME_2"].max_wait_time == 10
+        assert config.event_hubs["EVENTHUBNAME_2"].prefetch_count == 60
+        assert config.event_hubs["EVENTHUBNAME_2"].retry_total == 9

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1074,6 +1074,27 @@ class TestEvSnowConfig:
         assert config.target_schema == "public"
         assert config.target_table == "ingestion_status"
 
+    def test_local_single_consumer_ownership_mode_opt_in(self, monkeypatch):
+        """Test explicit Snowflake checkpoint smoke ownership mode opt-in."""
+        monkeypatch.setenv("CONTROL_OWNERSHIP_MODE", "local_single_consumer_smoke")
+
+        config = EvSnowConfig(eventhub_namespace="test.servicebus.windows.net")
+
+        assert config.control_ownership_mode == "local_single_consumer_smoke"
+
+    def test_local_single_consumer_ownership_mode_requires_snowflake_backend(self, monkeypatch):
+        """Test diagnostic ownership mode is limited to Snowflake checkpoint smoke tests."""
+        monkeypatch.setenv("CONTROL_PG_HOST", "localhost")
+        monkeypatch.setenv("CONTROL_PG_USER", "pguser")
+        monkeypatch.setenv("CONTROL_PG_PASSWORD", "pgpass")
+
+        with pytest.raises(ValueError, match="local_single_consumer_smoke"):
+            EvSnowConfig(
+                eventhub_namespace="test.servicebus.windows.net",
+                control_table_backend="postgres",
+                control_ownership_mode="local_single_consumer_smoke",
+            )
+
 
 class TestLoadConfig:
     """Tests for load_config function."""

--- a/tests/unit/test_eventhub.py
+++ b/tests/unit/test_eventhub.py
@@ -16,8 +16,7 @@ import json
 import logging
 import time
 from datetime import datetime, UTC, timedelta
-from typing import Any
-from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -419,9 +418,8 @@ class TestSnowflakeCheckpointManager:
             snowflake_config=sample_snowflake_connection_config,
         )
 
-        result = await manager.get_last_checkpoint()
-
-        assert result is None  # Should return None on error
+        with pytest.raises(Exception, match="DB error"):
+            await manager.get_last_checkpoint()
 
     @pytest.mark.asyncio
     async def test_save_checkpoint_to_snowflake(
@@ -656,28 +654,45 @@ class TestSnowflakeCheckpointStore:
 
     @pytest.mark.asyncio
     async def test_list_ownership_returns_cached_records(self):
-        """Test listing ownership records returns cache."""
+        """Test listing ownership records delegates to durable backend."""
         mock_manager = MagicMock()
+        mock_manager.list_ownership = AsyncMock(
+            return_value=[
+                {
+                    "partition_id": "0",
+                    "owner_id": "test-owner",
+                    "fully_qualified_namespace": "test.servicebus.windows.net",
+                    "eventhub_name": "test-hub",
+                    "consumer_group": "test-group",
+                }
+            ]
+        )
         store = SnowflakeCheckpointStore(mock_manager)
-
-        # Add some ownership to cache
-        store._ownership_cache["0"] = {
-            "partition_id": "0",
-            "owner_id": "test-owner",
-            "fully_qualified_namespace": "test.servicebus.windows.net",
-            "eventhub_name": "test-hub",
-            "consumer_group": "test-group",
-        }
 
         result = await store.list_ownership("test.servicebus.windows.net", "test-hub", "test-group")
 
         assert len(result) == 1
         assert result[0]["partition_id"] == "0"
+        mock_manager.list_ownership.assert_awaited_once_with(
+            "test.servicebus.windows.net",
+            "test-hub",
+            "test-group",
+        )
 
     @pytest.mark.asyncio
     async def test_claim_ownership_for_partitions(self):
         """Test claiming ownership for partitions."""
         mock_manager = MagicMock()
+        mock_manager.claim_ownership = AsyncMock(
+            side_effect=lambda ownership_list: [
+                {
+                    **ownership,
+                    "etag": f"etag-{ownership['partition_id']}",
+                    "last_modified_time": 123.0,
+                }
+                for ownership in ownership_list
+            ]
+        )
         store = SnowflakeCheckpointStore(mock_manager)
 
         ownership_list = [
@@ -702,6 +717,7 @@ class TestSnowflakeCheckpointStore:
         assert len(claimed) == 2
         assert all("etag" in c for c in claimed)
         assert all("last_modified_time" in c for c in claimed)
+        mock_manager.claim_ownership.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_update_checkpoint_via_sdk(self, mocker):
@@ -725,12 +741,13 @@ class TestSnowflakeCheckpointStore:
         # Should call manager's save_checkpoint
         mock_manager.save_checkpoint.assert_called_once()
         call_args = mock_manager.save_checkpoint.call_args
-        # Check that offset was converted to int
-        assert call_args[0][0] == {"0": 12345}
+        # Check that sequence number is stored separately from opaque Event Hub offset
+        assert call_args[0][0] == {"0": 100}
+        assert call_args[0][1]["0"]["offset_string"] == "12345"
 
     @pytest.mark.asyncio
     async def test_update_checkpoint_handles_invalid_offset(self, mocker):
-        """Test that invalid offset falls back to sequence number."""
+        """Test that opaque offsets are preserved in checkpoint metadata."""
         mock_manager = MagicMock()
         mock_manager.save_checkpoint = AsyncMock(return_value=True)
 
@@ -747,10 +764,30 @@ class TestSnowflakeCheckpointStore:
 
         await store.update_checkpoint(checkpoint)
 
-        # Should use sequence_number as fallback
         mock_manager.save_checkpoint.assert_called_once()
         call_args = mock_manager.save_checkpoint.call_args
-        assert call_args[0][0] == {"0": 100}  # Should use sequence_number
+        assert call_args[0][0] == {"0": 100}
+        assert call_args[0][1]["0"]["offset_string"] == "invalid"
+
+    @pytest.mark.asyncio
+    async def test_update_checkpoint_raises_when_manager_returns_false(self):
+        """Test that failed checkpoint persistence fails the SDK checkpoint call."""
+        mock_manager = MagicMock()
+        mock_manager.save_checkpoint = AsyncMock(return_value=False)
+
+        store = SnowflakeCheckpointStore(mock_manager)
+
+        checkpoint = {
+            "fully_qualified_namespace": "test.servicebus.windows.net",
+            "eventhub_name": "test-hub",
+            "consumer_group": "test-group",
+            "partition_id": "0",
+            "offset": "12345",
+            "sequence_number": 100,
+        }
+
+        with pytest.raises(RuntimeError, match="Failed to update checkpoint"):
+            await store.update_checkpoint(checkpoint)
 
     @pytest.mark.asyncio
     async def test_list_checkpoints_from_snowflake(self):
@@ -769,6 +806,31 @@ class TestSnowflakeCheckpointStore:
         assert all("partition_id" in c for c in result)
         # Offsets should be strings
         assert all(isinstance(c["offset"], str) for c in result)
+
+    @pytest.mark.asyncio
+    async def test_list_checkpoints_uses_persisted_offset_and_sequence_metadata(self):
+        """Test loading checkpoints preserves offset and sequence as separate values."""
+        mock_manager = MagicMock()
+        mock_manager.get_last_checkpoint = AsyncMock(
+            return_value={"0": {"offset": "abc-123", "sequence_number": 42}}
+        )
+
+        store = SnowflakeCheckpointStore(mock_manager)
+
+        result = await store.list_checkpoints(
+            "test.servicebus.windows.net", "test-hub", "test-group"
+        )
+
+        assert result == [
+            {
+                "fully_qualified_namespace": "test.servicebus.windows.net",
+                "eventhub_name": "test-hub",
+                "consumer_group": "test-group",
+                "partition_id": "0",
+                "offset": "abc-123",
+                "sequence_number": 42,
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_list_checkpoints_returns_empty_when_none(self):
@@ -883,6 +945,37 @@ class TestEventHubAsyncConsumer:
         assert consumer.checkpoint_manager is not None
 
     @pytest.mark.asyncio
+    async def test_start_accepts_metadata_shaped_checkpoints(
+        self,
+        mocker,
+        sample_eventhub_config,
+        mock_eventhub_client,
+        mock_azure_credential,
+        mock_logfire,
+    ):
+        """Test start logging handles offset/sequence checkpoint metadata."""
+        checkpoints = {"0": {"offset": "abc-123", "sequence_number": 42}}
+        mocker.patch("utils.snowflake.get_partition_checkpoints", return_value=checkpoints)
+
+        def mock_processor(messages):
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+
+        try:
+            await consumer.start()
+        except asyncio.CancelledError:
+            pass
+
+        assert consumer.stats["last_checkpoint"] == checkpoints
+
+    @pytest.mark.asyncio
     async def test_start_initializes_postgres_checkpoint_manager(
         self,
         mocker,
@@ -962,6 +1055,20 @@ class TestEventHubAsyncConsumer:
 
         # Should use from_connection_string
         mock_from_conn.assert_called_once()
+        client_kwargs = mock_from_conn.call_args.kwargs
+        assert client_kwargs["retry_total"] == 3
+        assert client_kwargs["retry_backoff_factor"] == 0.8
+        assert client_kwargs["retry_backoff_max"] == 120
+        assert client_kwargs["retry_mode"] == "exponential"
+        assert client_kwargs["load_balancing_interval"] == 30
+        assert client_kwargs["load_balancing_strategy"] == "greedy"
+        assert "checkpoint_store" in client_kwargs
+
+        receive_kwargs = mock_client.receive.await_args.kwargs
+        assert receive_kwargs["max_wait_time"] == 60
+        assert receive_kwargs["prefetch"] == 50
+        assert receive_kwargs["track_last_enqueued_event_properties"] is False
+        assert receive_kwargs["on_error"] == consumer._on_receive_error
 
     @pytest.mark.asyncio
     async def test_start_creates_eventhub_client_with_credential(
@@ -976,8 +1083,10 @@ class TestEventHubAsyncConsumer:
         )
         mock_cred.close = AsyncMock()
 
-        # AzureCliCredential is imported inside start(), so patch where it's imported from
-        mocker.patch("azure.identity.aio.AzureCliCredential", return_value=mock_cred)
+        # DefaultAzureCredential is imported inside the helper, so patch the SDK import site.
+        mock_default_credential = mocker.patch(
+            "azure.identity.aio.DefaultAzureCredential", return_value=mock_cred
+        )
 
         mock_client = AsyncMock()
         mock_client.receive = AsyncMock(side_effect=asyncio.CancelledError())
@@ -1006,6 +1115,97 @@ class TestEventHubAsyncConsumer:
 
         # Should create client with credential
         mock_client_class.assert_called_once()
+        mock_default_credential.assert_called_once_with()
+        client_kwargs = mock_client_class.call_args.kwargs
+        assert client_kwargs["credential"] is mock_cred
+        assert client_kwargs["retry_total"] == sample_eventhub_config.retry_total
+        assert client_kwargs["load_balancing_strategy"] == (
+            sample_eventhub_config.load_balancing_strategy
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_passes_managed_identity_client_id_to_default_credential(
+        self, mocker, sample_eventhub_config, mock_logfire
+    ):
+        """Test user-assigned managed identity client ID is passed to DefaultAzureCredential."""
+        mocker.patch("utils.snowflake.get_partition_checkpoints", return_value=None)
+        config = sample_eventhub_config.model_copy(
+            update={"managed_identity_client_id": "managed-client-id"}
+        )
+
+        mock_cred = AsyncMock()
+        mock_cred.get_token = AsyncMock(
+            return_value=MagicMock(token="test-token", expires_on=time.time() + 3600)
+        )
+        mock_cred.close = AsyncMock()
+        mock_default_credential = mocker.patch(
+            "azure.identity.aio.DefaultAzureCredential", return_value=mock_cred
+        )
+
+        mock_client = AsyncMock()
+        mock_client.receive = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_client.close = AsyncMock()
+        mocker.patch("consumers.eventhub.EventHubConsumerClient", return_value=mock_client)
+
+        def mock_processor(messages):
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+
+        try:
+            await consumer.start()
+        except asyncio.CancelledError:
+            pass
+
+        mock_default_credential.assert_called_once_with(
+            managed_identity_client_id="managed-client-id"
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_uses_azure_cli_credential_when_configured(
+        self, mocker, sample_eventhub_config, mock_logfire
+    ):
+        """Test AzureCliCredential is only used for explicit local-development opt-in."""
+        mocker.patch("utils.snowflake.get_partition_checkpoints", return_value=None)
+        config = sample_eventhub_config.model_copy(update={"credential_mode": "azure_cli"})
+
+        mock_cred = AsyncMock()
+        mock_cred.get_token = AsyncMock(
+            return_value=MagicMock(token="test-token", expires_on=time.time() + 3600)
+        )
+        mock_cred.close = AsyncMock()
+        mock_cli_credential = mocker.patch(
+            "azure.identity.aio.AzureCliCredential", return_value=mock_cred
+        )
+
+        mock_client = AsyncMock()
+        mock_client.receive = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_client.close = AsyncMock()
+        mocker.patch("consumers.eventhub.EventHubConsumerClient", return_value=mock_client)
+
+        def mock_processor(messages):
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+
+        try:
+            await consumer.start()
+        except asyncio.CancelledError:
+            pass
+
+        mock_cli_credential.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_process_messages_in_batches(
@@ -1116,10 +1316,391 @@ class TestEventHubAsyncConsumer:
         batch.add_message(message)
 
         consumer.running = True
-        await consumer._process_batch(batch)
+        result = await consumer._process_batch(batch)
 
         # Checkpoint should be updated
+        assert result is True
         mock_context.update_checkpoint.assert_called_once_with(mock_event)
+
+    @pytest.mark.asyncio
+    async def test_process_batch_returns_false_and_does_not_checkpoint_on_processor_failure(
+        self,
+        sample_eventhub_config,
+        mock_logfire,
+    ):
+        """Test that failed processing does not checkpoint the batch."""
+
+        def mock_processor(messages):
+            return False
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+
+        mock_context = MagicMock()
+        mock_context.partition_id = "0"
+        mock_context.update_checkpoint = AsyncMock()
+
+        mock_event = MagicMock()
+        mock_event.body_as_str.return_value = '{"test": "data"}'
+        mock_event.enqueued_time = datetime.now(UTC)
+        mock_event.properties = {}
+        mock_event.system_properties = {}
+        mock_event.sequence_number = 100
+        mock_event.offset = "12345"
+
+        message = EventHubMessage(event_data=mock_event, partition_id="0", sequence_number=100)
+        message.partition_context = mock_context
+        batch = MessageBatch(max_size=10, max_wait_seconds=60)
+        batch.add_message(message)
+
+        result = await consumer._process_batch(batch)
+
+        assert result is False
+        mock_context.update_checkpoint.assert_not_called()
+        assert consumer.stats["batches_processed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_on_event_keeps_batch_after_processing_failure(
+        self,
+        sample_eventhub_config,
+        mock_logfire,
+    ):
+        """Test that a failed ready batch is not cleared by _on_event."""
+
+        def mock_processor(messages):
+            return False
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+            batch_size=1,
+        )
+        consumer.running = True
+        mock_client = AsyncMock()
+        mock_client.close = AsyncMock()
+        consumer.client = mock_client
+        consumer.current_batch = MessageBatch(max_size=1, max_wait_seconds=60)
+        failed_batch = consumer.current_batch
+
+        mock_context = MagicMock()
+        mock_context.partition_id = "0"
+        mock_context.update_checkpoint = AsyncMock()
+
+        mock_event = MagicMock()
+        mock_event.body_as_str.return_value = '{"test": "data"}'
+        mock_event.enqueued_time = datetime.now(UTC)
+        mock_event.properties = {}
+        mock_event.system_properties = {}
+        mock_event.sequence_number = 100
+        mock_event.offset = "12345"
+
+        await consumer._on_event(mock_context, mock_event)
+
+        assert consumer.current_batch is failed_batch
+        assert len(consumer.current_batch.messages) == 1
+        assert consumer.running is False
+        assert consumer.client is None
+        mock_client.close.assert_called_once()
+        mock_context.update_checkpoint.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_event_detaches_batch_before_awaiting_processor(
+        self,
+        sample_eventhub_config,
+        mock_logfire,
+    ):
+        """Test that messages appended during processing are handled in a later batch."""
+        first_processor_started = asyncio.Event()
+        release_first_processor = asyncio.Event()
+        processed_sequences: list[list[int]] = []
+
+        async def mock_processor(messages):
+            processed_sequences.append([message.sequence_number for message in messages])
+            if len(processed_sequences) == 1:
+                first_processor_started.set()
+                await release_first_processor.wait()
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+            batch_size=1,
+        )
+        consumer.running = True
+        consumer.current_batch = MessageBatch(max_size=1, max_wait_seconds=60)
+
+        context = MagicMock()
+        context.partition_id = "0"
+        context.update_checkpoint = AsyncMock()
+
+        first_event = MagicMock()
+        first_event.body_as_str.return_value = '{"id": 1}'
+        first_event.enqueued_time = datetime.now(UTC)
+        first_event.properties = {}
+        first_event.system_properties = {}
+        first_event.sequence_number = 100
+        first_event.offset = "1000"
+
+        second_event = MagicMock()
+        second_event.body_as_str.return_value = '{"id": 2}'
+        second_event.enqueued_time = datetime.now(UTC)
+        second_event.properties = {}
+        second_event.system_properties = {}
+        second_event.sequence_number = 101
+        second_event.offset = "1001"
+
+        first_task = asyncio.create_task(consumer._on_event(context, first_event))
+        await first_processor_started.wait()
+        second_task = asyncio.create_task(consumer._on_event(context, second_event))
+        await asyncio.sleep(0)
+
+        release_first_processor.set()
+        await asyncio.gather(first_task, second_task)
+
+        assert processed_sequences == [[100], [101]]
+        assert context.update_checkpoint.call_args_list[0].args == (first_event,)
+        assert context.update_checkpoint.call_args_list[1].args == (second_event,)
+        assert consumer.stats["batches_processed"] == 2
+
+    @pytest.mark.asyncio
+    async def test_failed_batch_restore_preserves_detach_order(
+        self,
+        sample_eventhub_config,
+        mock_logfire,
+    ):
+        """Test that queued detached batches are restored after the first failed batch."""
+        first_processor_started = asyncio.Event()
+        release_first_processor = asyncio.Event()
+        processed_sequences: list[list[int]] = []
+
+        async def mock_processor(messages):
+            processed_sequences.append([message.sequence_number for message in messages])
+            first_processor_started.set()
+            await release_first_processor.wait()
+            return False
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+            batch_size=1,
+        )
+        consumer.running = True
+        consumer.client = AsyncMock()
+        consumer.client.close = AsyncMock()
+        consumer.current_batch = MessageBatch(max_size=1, max_wait_seconds=60)
+
+        context = MagicMock()
+        context.partition_id = "0"
+        context.update_checkpoint = AsyncMock()
+
+        first_event = MagicMock()
+        first_event.body_as_str.return_value = '{"id": 1}'
+        first_event.enqueued_time = datetime.now(UTC)
+        first_event.properties = {}
+        first_event.system_properties = {}
+        first_event.sequence_number = 100
+        first_event.offset = "1000"
+
+        second_event = MagicMock()
+        second_event.body_as_str.return_value = '{"id": 2}'
+        second_event.enqueued_time = datetime.now(UTC)
+        second_event.properties = {}
+        second_event.system_properties = {}
+        second_event.sequence_number = 101
+        second_event.offset = "1001"
+
+        first_task = asyncio.create_task(consumer._on_event(context, first_event))
+        await first_processor_started.wait()
+        second_task = asyncio.create_task(consumer._on_event(context, second_event))
+        await asyncio.sleep(0)
+
+        release_first_processor.set()
+        await asyncio.gather(first_task, second_task)
+
+        assert processed_sequences == [[100]]
+        assert [message.sequence_number for message in consumer.current_batch.messages] == [
+            100,
+            101,
+        ]
+        assert consumer.current_batch.last_sequence_by_partition == {"0": 101}
+        assert consumer.running is False
+        context.update_checkpoint.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_failed_batch_restore_keeps_detached_batches_before_current_partial(
+        self,
+        sample_eventhub_config,
+        mock_logfire,
+    ):
+        """Test restore order is detached backlog first, then newer partial batch."""
+
+        def mock_processor(messages):
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+
+        batches = []
+        for sequence_number in (100, 101, 102):
+            mock_event = MagicMock()
+            mock_event.body_as_str.return_value = f'{{"id": {sequence_number}}}'
+            mock_event.enqueued_time = datetime.now(UTC)
+            mock_event.properties = {}
+            mock_event.system_properties = {}
+            mock_event.sequence_number = sequence_number
+            mock_event.offset = str(sequence_number)
+
+            message = EventHubMessage(
+                event_data=mock_event,
+                partition_id="0",
+                sequence_number=sequence_number,
+            )
+            batch = MessageBatch(max_size=10, max_wait_seconds=60)
+            batch.add_message(message)
+            batches.append(batch)
+
+        batch_a, batch_b, batch_c = batches
+        consumer._detached_batches = [batch_a, batch_b]
+        consumer.current_batch = batch_c
+
+        await consumer._restore_failed_batch(batch_a)
+        await consumer._restore_failed_batch(batch_b)
+
+        assert [message.sequence_number for message in consumer.current_batch.messages] == [
+            100,
+            101,
+            102,
+        ]
+        assert consumer.current_batch.last_sequence_by_partition == {"0": 102}
+
+    @pytest.mark.asyncio
+    async def test_run_message_processor_awaits_async_callable_instance(
+        self,
+        sample_eventhub_config,
+        mock_logfire,
+    ):
+        """Test async callable processors are awaited before success is returned."""
+        processor_completed = False
+
+        class AsyncCallableProcessor:
+            async def __call__(self, messages):
+                nonlocal processor_completed
+                await asyncio.sleep(0)
+                processor_completed = True
+                return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=AsyncCallableProcessor(),
+        )
+
+        result = await consumer._run_message_processor([])
+
+        assert result is True
+        assert processor_completed is True
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_update_failure_marks_batch_failed(
+        self,
+        mocker,
+        sample_eventhub_config,
+        mock_logfire,
+    ):
+        """Test that exhausted checkpoint retries fail the batch."""
+
+        def mock_processor(messages):
+            return True
+
+        mocker.patch("asyncio.sleep", new=AsyncMock())
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+
+        mock_context = MagicMock()
+        mock_context.partition_id = "0"
+        mock_context.update_checkpoint = AsyncMock(side_effect=Exception("checkpoint down"))
+
+        mock_event = MagicMock()
+        mock_event.body_as_str.return_value = '{"test": "data"}'
+        mock_event.enqueued_time = datetime.now(UTC)
+        mock_event.properties = {}
+        mock_event.system_properties = {}
+        mock_event.sequence_number = 100
+        mock_event.offset = "12345"
+
+        message = EventHubMessage(event_data=mock_event, partition_id="0", sequence_number=100)
+        message.partition_context = mock_context
+        batch = MessageBatch(max_size=10, max_wait_seconds=60)
+        batch.add_message(message)
+
+        result = await consumer._process_batch(batch)
+
+        assert result is False
+        assert mock_context.update_checkpoint.call_count == 3
+        assert consumer.stats["batches_processed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_process_batch_returns_false_without_partition_context(
+        self,
+        sample_eventhub_config,
+        mock_logfire,
+    ):
+        """Test that missing partition context fails the batch before stats advance."""
+
+        def mock_processor(messages):
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+
+        mock_event = MagicMock()
+        mock_event.body_as_str.return_value = '{"test": "data"}'
+        mock_event.enqueued_time = datetime.now(UTC)
+        mock_event.properties = {}
+        mock_event.system_properties = {}
+        mock_event.sequence_number = 100
+        mock_event.offset = "12345"
+
+        message = EventHubMessage(event_data=mock_event, partition_id="0", sequence_number=100)
+        batch = MessageBatch(max_size=10, max_wait_seconds=60)
+        batch.add_message(message)
+
+        result = await consumer._process_batch(batch)
+
+        assert result is False
+        assert consumer.stats["batches_processed"] == 0
 
     @pytest.mark.asyncio
     async def test_stop_consumer_and_cleanup_resources(
@@ -1215,7 +1796,7 @@ class TestEventHubAsyncConsumer:
         # Mock credential to raise error
         mock_cred = AsyncMock()
         mock_cred.get_token = AsyncMock(side_effect=Exception("Connection failed"))
-        mocker.patch("azure.identity.aio.AzureCliCredential", return_value=mock_cred)
+        mocker.patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_cred)
 
         def mock_processor(messages):
             return True
@@ -1234,6 +1815,117 @@ class TestEventHubAsyncConsumer:
 
         # Consumer should not be running
         assert consumer.running is False
+
+    @pytest.mark.asyncio
+    async def test_on_receive_error_raises(self, sample_eventhub_config):
+        """Test receive callback errors stop the SDK receive loop."""
+
+        def mock_processor(messages):
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+        mock_client = AsyncMock()
+        mock_client.close = AsyncMock()
+        consumer.client = mock_client
+        consumer.running = True
+        context = MagicMock()
+        context.partition_id = "0"
+        error = RuntimeError("partition failure")
+
+        await consumer._on_receive_error(context, error)
+
+        assert consumer.running is False
+        assert consumer._receive_error is error
+        assert consumer._receive_error_close_task is not None
+        await consumer._receive_error_close_task
+        mock_client.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_raises_receive_error_even_when_sdk_swallows_on_error(
+        self, mocker, sample_eventhub_config, mock_logfire
+    ):
+        """Test stored on_error exceptions preserve the fail-closed receive contract."""
+        mocker.patch("utils.snowflake.get_partition_checkpoints", return_value=None)
+
+        mock_cred = AsyncMock()
+        mock_cred.get_token = AsyncMock(
+            return_value=MagicMock(token="test-token", expires_on=time.time() + 3600)
+        )
+        mock_cred.close = AsyncMock()
+        mocker.patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_cred)
+
+        error = RuntimeError("load balancing failed")
+        mock_client = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        async def receive_side_effect(**kwargs):
+            await kwargs["on_error"](None, error)
+
+        mock_client.receive = AsyncMock(side_effect=receive_side_effect)
+        mocker.patch("consumers.eventhub.EventHubConsumerClient", return_value=mock_client)
+
+        def mock_processor(messages):
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+
+        with pytest.raises(RuntimeError, match="load balancing failed"):
+            await consumer.start()
+
+        assert consumer.running is False
+        mock_client.close.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_fails_closed_on_receive_credential_error(
+        self, mocker, sample_eventhub_config, mock_logfire
+    ):
+        """Test credential-looking receive errors stop and clean up the consumer."""
+        mocker.patch("utils.snowflake.get_partition_checkpoints", return_value=None)
+
+        mock_cred = AsyncMock()
+        mock_cred.get_token = AsyncMock(
+            return_value=MagicMock(token="test-token", expires_on=time.time() + 3600)
+        )
+        mock_cred.close = AsyncMock()
+        mocker.patch("azure.identity.aio.DefaultAzureCredential", return_value=mock_cred)
+
+        mock_client = AsyncMock()
+        mock_client.receive = AsyncMock(
+            side_effect=RuntimeError("DefaultAzureCredential failed")
+        )
+        mock_client.close = AsyncMock()
+        mocker.patch("consumers.eventhub.EventHubConsumerClient", return_value=mock_client)
+
+        def mock_processor(messages):
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+
+        with pytest.raises(RuntimeError, match="DefaultAzureCredential failed"):
+            await consumer.start()
+
+        assert consumer.running is False
+        assert consumer.client is None
+        mock_client.close.assert_awaited()
+        mock_cred.close.assert_awaited()
 
     def test_get_stats_returns_statistics(self, sample_eventhub_config):
         """Test that get_stats returns consumer statistics."""

--- a/tests/unit/test_eventhub.py
+++ b/tests/unit/test_eventhub.py
@@ -15,7 +15,7 @@ import asyncio
 import json
 import logging
 import time
-from datetime import datetime, UTC, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -27,11 +27,11 @@ from consumers.eventhub import (
     MessageBatch,
     PostgresCheckpointManager,
     PostgresCheckpointStore,
+    SingleConsumerSnowflakeCheckpointStore,
     SnowflakeCheckpointManager,
     SnowflakeCheckpointStore,
     _convert_bytes_to_str,
 )
-
 
 # ============================================================================
 # Tests for BytesEncoder
@@ -720,6 +720,51 @@ class TestSnowflakeCheckpointStore:
         mock_manager.claim_ownership.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_single_consumer_store_keeps_ownership_local(self):
+        """Test local ownership mode avoids Snowflake durable ownership calls."""
+        mock_manager = MagicMock()
+        store = SingleConsumerSnowflakeCheckpointStore(mock_manager)
+        ownership = {
+            "fully_qualified_namespace": "test.servicebus.windows.net",
+            "eventhub_name": "test-hub",
+            "consumer_group": "test-group",
+            "partition_id": "0",
+            "owner_id": "owner-1",
+        }
+
+        claimed = await store.claim_ownership([ownership])
+        listed = await store.list_ownership(
+            "test.servicebus.windows.net",
+            "test-hub",
+            "test-group",
+        )
+
+        assert len(claimed) == 1
+        assert claimed[0]["partition_id"] == "0"
+        assert "etag" in claimed[0]
+        assert listed == claimed
+        mock_manager.claim_ownership.assert_not_called()
+        mock_manager.list_ownership.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_single_consumer_store_rejects_stale_etag(self):
+        """Test local ownership honors the SDK etag compare-and-set shape."""
+        store = SingleConsumerSnowflakeCheckpointStore(MagicMock())
+        ownership = {
+            "fully_qualified_namespace": "test.servicebus.windows.net",
+            "eventhub_name": "test-hub",
+            "consumer_group": "test-group",
+            "partition_id": "0",
+            "owner_id": "owner-1",
+        }
+
+        claimed = await store.claim_ownership([ownership])
+        stale_claim = {**ownership, "owner_id": "owner-2", "etag": "stale"}
+
+        assert claimed
+        assert await store.claim_ownership([stale_claim]) == []
+
+    @pytest.mark.asyncio
     async def test_update_checkpoint_via_sdk(self, mocker):
         """Test updating checkpoint through SDK interface."""
         mock_manager = MagicMock()
@@ -906,9 +951,96 @@ class TestEventHubAsyncConsumer:
         assert consumer.target_table == "TEST_TABLE"
         assert consumer.batch_size == 100
         assert consumer.batch_timeout_seconds == 60
+
+    @pytest.mark.asyncio
+    async def test_stop_waits_for_active_batch_processing(self, sample_eventhub_config):
+        """Test shutdown waits before downstream clients are closed."""
+
+        def mock_processor(messages):
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+        )
+        consumer.running = True
+        mock_client = AsyncMock()
+        mock_client.close = AsyncMock()
+        consumer.client = mock_client
+        consumer.checkpoint_manager = MagicMock()
+
+        await consumer._processing_lock.acquire()
+        stop_task = asyncio.create_task(consumer.stop())
+        await asyncio.sleep(0)
+
+        mock_client.close.assert_not_called()
+
+        consumer._processing_lock.release()
+        await stop_task
+
+        mock_client.close.assert_awaited_once()
         assert consumer.running is False
         assert consumer.client is None
         assert consumer.checkpoint_manager is None
+
+    @pytest.mark.asyncio
+    async def test_stop_waits_for_active_on_event_before_final_drain(
+        self, sample_eventhub_config
+    ):
+        """Test shutdown waits for already-dispatched callbacks before final batch drain."""
+        processed_sequences = []
+
+        def mock_processor(messages):
+            processed_sequences.extend(message.sequence_number for message in messages)
+            return True
+
+        consumer = EventHubAsyncConsumer(
+            eventhub_config=sample_eventhub_config,
+            target_db="TEST_DB",
+            target_schema="TEST_SCHEMA",
+            target_table="TEST_TABLE",
+            message_processor=mock_processor,
+            batch_size=10,
+        )
+        consumer.running = True
+        consumer.current_batch = MessageBatch(max_size=10, max_wait_seconds=60)
+        mock_client = AsyncMock()
+        mock_client.close = AsyncMock()
+        consumer.client = mock_client
+        consumer.checkpoint_manager = MagicMock()
+
+        context = MagicMock()
+        context.partition_id = "0"
+        context.update_checkpoint = AsyncMock()
+
+        event = MagicMock()
+        event.body_as_str.return_value = '{"test": "data"}'
+        event.enqueued_time = datetime.now(UTC)
+        event.properties = {}
+        event.system_properties = {}
+        event.sequence_number = 100
+        event.offset = "12345"
+
+        await consumer._batch_lock.acquire()
+        event_task = asyncio.create_task(consumer._on_event(context, event))
+        await asyncio.sleep(0)
+
+        stop_task = asyncio.create_task(consumer.stop())
+        await asyncio.sleep(0)
+
+        mock_client.close.assert_not_called()
+        context.update_checkpoint.assert_not_called()
+
+        consumer._batch_lock.release()
+        await asyncio.gather(event_task, stop_task)
+
+        assert processed_sequences == [100]
+        context.update_checkpoint.assert_awaited_once_with(event)
+        mock_client.close.assert_awaited_once()
+        assert consumer.client is None
 
     @pytest.mark.asyncio
     async def test_start_initializes_checkpoint_manager(

--- a/tests/unit/test_eventhub_coverage.py
+++ b/tests/unit/test_eventhub_coverage.py
@@ -41,10 +41,6 @@ def test_log_no_checkpoint_behavior_variants(sample_eventhub_config, caplog):
     consumer._log_no_checkpoint_behavior("@latest")
     assert "LATEST" in caplog.text
 
-    caplog.clear()
-    consumer._log_no_checkpoint_behavior("0")
-    assert "offset 0" in caplog.text
-
 
 @pytest.mark.unit
 def test_log_rbac_permission_validation_notice(sample_eventhub_config, caplog):
@@ -58,7 +54,7 @@ def test_log_rbac_permission_validation_notice(sample_eventhub_config, caplog):
 
 
 @pytest.mark.unit
-def test_handle_receive_error_credential_error_is_swallowed(
+def test_handle_receive_error_credential_error_fails_closed(
     sample_eventhub_config, monkeypatch
 ):
     consumer = _make_consumer(sample_eventhub_config)
@@ -74,7 +70,7 @@ def test_handle_receive_error_credential_error_is_swallowed(
     exc = RuntimeError("Failed to retrieve a token from Azure CLI credential")
     handled = consumer._handle_receive_error(exc)
 
-    assert handled is True
+    assert handled is False
     assert calls["count"] == 1
 
 

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -17,7 +17,7 @@ import asyncio
 import signal
 import sys
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -298,28 +298,22 @@ class TestPipelineMapping:
         assert mapping.stats["batches_processed"] == 1
         assert mapping.stats["last_activity"] is not None
         assert mock_snowflake_client.ingest_batch.call_count == 3
-
-        calls = mock_snowflake_client.ingest_batch.call_args_list
-        assert [ingest_call.kwargs["partition_id"] for ingest_call in calls] == ["0", "1", "2"]
-        assert [ingest_call.kwargs["channel_name"] for ingest_call in calls] == [
-            f"{mapping.channel_name}-p0",
-            f"{mapping.channel_name}-p1",
-            f"{mapping.channel_name}-p2",
-        ]
-
-        sequences_by_partition = {
-            ingest_call.kwargs["partition_id"]: [
-                row["sequence_number"] for row in ingest_call.kwargs["data_batch"]
-            ]
-            for ingest_call in calls
+        called_partitions = {
+            ingest_call.kwargs["partition_id"]
+            for ingest_call in mock_snowflake_client.ingest_batch.call_args_list
         }
-        assert sequences_by_partition == {
-            "0": [100, 103, 106, 109],
-            "1": [101, 104, 107],
-            "2": [102, 105, 108],
-        }
+        assert called_partitions == {"0", "1", "2"}
 
-    def test_process_messages_sanitizes_partition_channel_suffix(
+        for ingest_call in mock_snowflake_client.ingest_batch.call_args_list:
+            partition_id = ingest_call.kwargs["partition_id"]
+            assert ingest_call.kwargs["channel_name"] == mapping._channel_name_for_partition(
+                partition_id
+            )
+            assert {
+                row["partition_id"] for row in ingest_call.kwargs["data_batch"]
+            } == {partition_id}
+
+    def test_process_messages_returns_false_if_any_partition_ingest_fails(
         self,
         complete_pipeline_config,
         sample_mapping,
@@ -328,7 +322,7 @@ class TestPipelineMapping:
         mock_snowflake_client,
         mock_logfire,
     ):
-        """Test that partition channel suffixes are safe for Snowflake channel names."""
+        """Test that _process_messages fails the batch if one partition fails."""
         # Arrange
         mapping = PipelineMapping(
             mapping_config=sample_mapping,
@@ -336,27 +330,20 @@ class TestPipelineMapping:
         )
         mapping.start()
 
-        messages = sample_eventhub_messages[:3]
-        messages[0].partition_id = "partition/1"
-        messages[0].sequence_number = 2
-        messages[1].partition_id = "partition/1"
-        messages[1].sequence_number = 1
-        messages[2].partition_id = "space partition"
+        def fail_partition_one(*, channel_name, data_batch, partition_id):
+            return partition_id != "1"
+
+        mock_snowflake_client.ingest_batch.side_effect = fail_partition_one
 
         # Act
-        result = mapping._process_messages(messages)
+        result = mapping._process_messages(sample_eventhub_messages)
 
         # Assert
-        assert result is True
-        assert [
-            ingest_call.kwargs["channel_name"]
-            for ingest_call in mock_snowflake_client.ingest_batch.call_args_list
-        ] == [
-            f"{mapping.channel_name}-ppartition-1",
-            f"{mapping.channel_name}-pspace-partition",
-        ]
-        first_batch = mock_snowflake_client.ingest_batch.call_args_list[0].kwargs["data_batch"]
-        assert [row["sequence_number"] for row in first_batch] == [1, 2]
+        assert result is False
+        assert mapping.stats["messages_processed"] == 0
+        assert mapping.stats["batches_processed"] == 0
+        assert len(mapping.stats["errors"]) == 1
+        assert mapping.stats["errors"][0]["partition_id"] == "1"
 
     def test_process_messages_without_snowflake_client_returns_false(
         self, complete_pipeline_config, sample_mapping, sample_eventhub_messages, mock_logfire

--- a/tests/unit/test_postgres_utils.py
+++ b/tests/unit/test_postgres_utils.py
@@ -1,10 +1,11 @@
 """Tests for Postgres control table utilities."""
 
-import pytest
 from unittest.mock import MagicMock, Mock
 
-from utils.config_models import PostgresConnectionConfig
+import pytest
+
 from utils import postgres as pg
+from utils.config_models import PostgresConnectionConfig
 
 
 def test_get_connection_password_auth_uses_password(mocker):
@@ -107,24 +108,65 @@ def test_insert_partition_checkpoint_executes(monkeypatch):
     assert executed.get("called") is True
 
 
+def test_ensure_postgres_ownership_table_uses_advisory_lock():
+    """Ownership table DDL is serialized for concurrent fresh consumers."""
+    cursor = MagicMock()
+
+    pg._ensure_postgres_ownership_table(cursor, "public", "ingestion_status_ownership")
+
+    assert cursor.execute.call_count == 3
+    lock_query, lock_params = cursor.execute.call_args_list[0].args
+    create_query = cursor.execute.call_args_list[1].args[0]
+    unlock_query, unlock_params = cursor.execute.call_args_list[2].args
+
+    assert lock_query == "SELECT pg_advisory_lock(%s)"
+    assert unlock_query == "SELECT pg_advisory_unlock(%s)"
+    assert lock_params == unlock_params
+    assert isinstance(lock_params[0], int)
+    assert "CREATE TABLE IF NOT EXISTS" in str(create_query)
+
+
+def test_ensure_postgres_ownership_table_unlocks_after_ddl_failure():
+    """The session advisory lock is released even if ownership DDL fails."""
+    calls = []
+
+    class DummyCursor:
+        def execute(self, query, params=None):
+            calls.append((query, params))
+            if len(calls) == 2:
+                raise RuntimeError("ddl failed")
+
+    with pytest.raises(RuntimeError, match="ddl failed"):
+        pg._ensure_postgres_ownership_table(
+            DummyCursor(),
+            "public",
+            "ingestion_status_ownership",
+        )
+
+    assert len(calls) == 3
+    assert calls[0][0] == "SELECT pg_advisory_lock(%s)"
+    assert calls[2][0] == "SELECT pg_advisory_unlock(%s)"
+    assert calls[0][1] == calls[2][1]
+
+
 def test_get_connection_azure_token_auth_success(mocker):
     """Ensure azure_token auth retrieves token and passes it to psycopg.connect."""
     # Reset the global azure credential cache to ensure clean test
     pg._azure_credential = None
-    
+
     dummy_conn = MagicMock()
     dummy_conn.closed = False
 
     mock_connect = mocker.patch("utils.postgres.psycopg.connect", return_value=dummy_conn)
-    
+
     # Mock the Azure credential and token
     mock_token = Mock()
     mock_token.token = "mock-azure-token-12345"
     mock_token.expires_on = 1234567890
-    
+
     mock_credential = Mock()
     mock_credential.get_token = Mock(return_value=mock_token)
-    
+
     mock_default_azure_credential = mocker.patch(
         "utils.postgres.DefaultAzureCredential",
         return_value=mock_credential
@@ -155,15 +197,15 @@ def test_get_connection_azure_token_auth_failure(mocker):
     """Ensure azure_token auth raises exception when token acquisition fails."""
     # Reset the global azure credential cache to ensure clean test
     pg._azure_credential = None
-    
+
     # Mock psycopg.connect so we don't make real connection attempts
     mocker.patch("utils.postgres.psycopg.connect")
-    
+
     mock_credential = Mock()
     mock_credential.get_token = Mock(
         side_effect=Exception("Failed to acquire Azure token")
     )
-    
+
     mocker.patch(
         "utils.postgres.DefaultAzureCredential",
         return_value=mock_credential
@@ -180,7 +222,7 @@ def test_get_connection_azure_token_auth_failure(mocker):
     # Should raise an exception when trying to get connection
     with pytest.raises(Exception) as exc_info:
         pg.get_connection(config, "control_db", use_cache=False)
-    
+
     assert "Failed to acquire Azure token" in str(exc_info.value)
     mock_credential.get_token.assert_called_once_with(
         "https://ossrdbms-aad.database.windows.net/.default"

--- a/tests/unit/test_postgres_utils.py
+++ b/tests/unit/test_postgres_utils.py
@@ -63,7 +63,10 @@ def test_get_partition_checkpoints_returns_dict(monkeypatch):
         config=MagicMock(),
     )
 
-    assert result == {"0": 123, "1": 456}
+    assert result == {
+        "0": {"offset": "123", "sequence_number": 123},
+        "1": {"offset": "456", "sequence_number": 456},
+    }
 
 
 def test_insert_partition_checkpoint_executes(monkeypatch):

--- a/tests/unit/test_postgres_utils.py
+++ b/tests/unit/test_postgres_utils.py
@@ -126,6 +126,17 @@ def test_ensure_postgres_ownership_table_uses_advisory_lock():
     assert "CREATE TABLE IF NOT EXISTS" in str(create_query)
 
 
+def test_advisory_lock_key_is_stable_signed_bigint():
+    """Lock keys stay stable and fit Postgres pg_advisory_lock(bigint)."""
+    first = pg._advisory_lock_key("evsnow", "public", "ingestion_status_ownership")
+    second = pg._advisory_lock_key("evsnow", "public", "ingestion_status_ownership")
+    different = pg._advisory_lock_key("evsnow", "public", "other_ownership")
+
+    assert first == second
+    assert first != different
+    assert -(2**63) <= first <= 2**63 - 1
+
+
 def test_ensure_postgres_ownership_table_unlocks_after_ddl_failure():
     """The session advisory lock is released even if ownership DDL fails."""
     calls = []

--- a/tests/unit/test_snowflake_client.py
+++ b/tests/unit/test_snowflake_client.py
@@ -12,6 +12,7 @@ This module tests the SnowflakeHighPerformanceStreamingClient class including:
 """
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -603,8 +604,9 @@ class TestSnowflakeHighPerformanceStreamingClient:
         # Set up mock channel
         mock_channel = MagicMock()
         mock_channel.append_rows.return_value = None
-        mock_channel.get_latest_committed_offset_token.return_value = None
+        mock_channel.initiate_flush.return_value = None
         mock_channel.wait_for_commit.return_value = None
+        mock_channel.get_latest_committed_offset_token.return_value = "offset_123"
 
         mock_get_or_create = mocker.patch.object(
             client, "_get_or_create_channel", return_value=mock_channel
@@ -622,12 +624,13 @@ class TestSnowflakeHighPerformanceStreamingClient:
 
         # Assert
         assert result is True
-        mock_get_or_create.assert_called_once_with("test_channel")
         mock_channel.append_rows.assert_called_once_with(
             data_batch,
-            start_offset_token="1",
-            end_offset_token="3",
+            start_offset_token="partition_0_1",
+            end_offset_token="partition_0_3",
         )
+        mock_channel.append_row.assert_not_called()
+        mock_channel.initiate_flush.assert_called_once_with()
         mock_channel.wait_for_commit.assert_called_once()
         assert client.stats["total_messages_sent"] == 3
         assert client.stats["total_batches_sent"] == 1
@@ -661,21 +664,21 @@ class TestSnowflakeHighPerformanceStreamingClient:
         # Act
         client._ingest_batch_impl("test_channel", data_batch, "partition_5")
 
-        # Assert - verify current SDK append_rows offset-token API is used
+        # Assert - verify offset tokens use partition_id and sequence_number
         mock_channel.append_rows.assert_called_once_with(
             data_batch,
-            start_offset_token="100",
-            end_offset_token="101",
+            start_offset_token="partition_5_100",
+            end_offset_token="partition_5_101",
         )
 
-    def test_ingest_batch_impl_skips_rows_at_or_below_committed_offset(
+    def test_ingest_batch_impl_skips_already_committed_rows(
         self,
         sample_snowflake_config,
         sample_snowflake_connection_config,
         mock_logfire,
         mocker,
     ):
-        """Test replay rows already committed by Snowflake are not appended again."""
+        """Test that _ingest_batch_impl skips rows already committed in Snowflake."""
         # Arrange
         client = SnowflakeHighPerformanceStreamingClient(
             snowflake_config=sample_snowflake_config,
@@ -683,13 +686,12 @@ class TestSnowflakeHighPerformanceStreamingClient:
         )
 
         mock_channel = MagicMock()
-        mock_channel.get_latest_committed_offset_token.return_value = "101"
+        mock_channel.get_latest_committed_offset_token.return_value = "partition_5_100"
         mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
 
         data_batch = [
             {"sequence_number": 100, "data": "row1"},
             {"sequence_number": 101, "data": "row2"},
-            {"sequence_number": 102, "data": "row3"},
         ]
 
         # Act
@@ -698,22 +700,20 @@ class TestSnowflakeHighPerformanceStreamingClient:
         # Assert
         assert result is True
         mock_channel.append_rows.assert_called_once_with(
-            [{"sequence_number": 102, "data": "row3"}],
-            start_offset_token="102",
-            end_offset_token="102",
+            [{"sequence_number": 101, "data": "row2"}],
+            start_offset_token="partition_5_101",
+            end_offset_token="partition_5_101",
         )
-        mock_channel.wait_for_commit.assert_called_once()
         assert client.stats["total_messages_sent"] == 1
-        assert client.stats["total_batches_sent"] == 1
 
-    def test_ingest_batch_impl_returns_success_when_replay_batch_is_fully_committed(
+    def test_ingest_batch_impl_checks_status_when_rows_already_committed(
         self,
         sample_snowflake_config,
         sample_snowflake_connection_config,
         mock_logfire,
         mocker,
     ):
-        """Test a fully replayed committed batch succeeds without sending rows."""
+        """Test that committed replay still checks Snowflake row status."""
         # Arrange
         client = SnowflakeHighPerformanceStreamingClient(
             snowflake_config=sample_snowflake_config,
@@ -721,121 +721,19 @@ class TestSnowflakeHighPerformanceStreamingClient:
         )
 
         mock_channel = MagicMock()
-        mock_channel.get_latest_committed_offset_token.return_value = "102"
+        mock_channel.get_latest_committed_offset_token.return_value = "partition_5_101"
         mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
 
-        data_batch = [
-            {"sequence_number": 100, "data": "row1"},
-            {"sequence_number": 101, "data": "row2"},
-            {"sequence_number": 102, "data": "row3"},
-        ]
-
-        # Act
-        result = client._ingest_batch_impl("test_channel", data_batch, "partition_5")
-
-        # Assert
-        assert result is True
-        mock_channel.append_rows.assert_not_called()
-        mock_channel.wait_for_commit.assert_not_called()
-        assert client.stats["total_messages_sent"] == 0
-        assert client.stats["total_batches_sent"] == 0
-
-    def test_ingest_batch_impl_falls_back_to_append_row_when_append_rows_missing(
-        self,
-        sample_snowflake_config,
-        sample_snowflake_connection_config,
-        mock_logfire,
-        mocker,
-    ):
-        """Test compatibility with SDK/mock channels that only expose append_row."""
-        # Arrange
-        client = SnowflakeHighPerformanceStreamingClient(
-            snowflake_config=sample_snowflake_config,
-            connection_config=sample_snowflake_connection_config,
+        status = SimpleNamespace(
+            channel_name="test_channel",
+            status_code="ACTIVE",
+            rows_inserted_count=0,
+            rows_parsed_count=2,
+            rows_error_count=1,
+            last_error_message="bad replayed row",
+            last_error_timestamp=None,
+            last_error_offset_token_upper_bound="partition_5_101",
         )
-
-        mock_channel = MagicMock()
-        del mock_channel.append_rows
-        mock_channel.get_latest_committed_offset_token.return_value = None
-        mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
-
-        data_batch = [
-            {"sequence_number": 200, "data": "row1"},
-            {"sequence_number": 201, "data": "row2"},
-        ]
-
-        # Act
-        result = client._ingest_batch_impl("test_channel", data_batch, "partition_9")
-
-        # Assert
-        assert result is True
-        assert mock_channel.append_row.call_count == 2
-        mock_channel.append_row.assert_any_call(data_batch[0], offset_token="200")
-        mock_channel.append_row.assert_any_call(data_batch[1], offset_token="201")
-        mock_channel.wait_for_commit.assert_called_once()
-
-    def test_ingest_batch_impl_waits_for_commit_to_reach_end_offset(
-        self,
-        sample_snowflake_config,
-        sample_snowflake_connection_config,
-        mock_logfire,
-        mocker,
-    ):
-        """Test wait_for_commit checker accepts committed tokens at or after the end token."""
-        # Arrange
-        client = SnowflakeHighPerformanceStreamingClient(
-            snowflake_config=sample_snowflake_config,
-            connection_config=sample_snowflake_connection_config,
-        )
-
-        mock_channel = MagicMock()
-        mock_channel.get_latest_committed_offset_token.return_value = None
-        mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
-
-        data_batch = [
-            {"sequence_number": 300, "data": "row1"},
-            {"sequence_number": 301, "data": "row2"},
-        ]
-
-        # Act
-        client._ingest_batch_impl("test_channel", data_batch, "partition_3")
-
-        # Assert
-        token_checker = mock_channel.wait_for_commit.call_args.args[0]
-        assert token_checker("300") is False
-        assert token_checker("301") is True
-        assert token_checker("302") is True
-        assert mock_channel.wait_for_commit.call_args.kwargs["timeout_seconds"] == (
-            sample_snowflake_config.connection_timeout_seconds
-        )
-
-    def test_ingest_batch_impl_raises_when_channel_reports_row_errors(
-        self,
-        sample_snowflake_config,
-        sample_snowflake_connection_config,
-        mock_logfire,
-        mocker,
-    ):
-        """Test Snowflake server-side row errors fail the batch before checkpointing."""
-        # Arrange
-        sample_snowflake_config.channel_status_interval_seconds = 60
-        client = SnowflakeHighPerformanceStreamingClient(
-            snowflake_config=sample_snowflake_config,
-            connection_config=sample_snowflake_connection_config,
-        )
-
-        mock_channel = MagicMock()
-        mock_channel.get_latest_committed_offset_token.return_value = None
-        mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
-
-        status = MagicMock()
-        status.channel_name = "test_channel"
-        status.status_code = "OK"
-        status.rows_inserted_count = 0
-        status.rows_parsed_count = 1
-        status.rows_error_count = 1
-        status.last_error_message = "invalid schema"
-        status.last_error_timestamp = None
         client.streaming_client = MagicMock()
         client.streaming_client.get_channel_statuses.return_value = {"test_channel": status}
 
@@ -843,59 +741,199 @@ class TestSnowflakeHighPerformanceStreamingClient:
         with pytest.raises(RuntimeError, match="reported row errors"):
             client._ingest_batch_impl(
                 "test_channel",
-                [{"sequence_number": 300, "data": "row1"}],
-                "partition_3",
+                [
+                    {"sequence_number": 100, "data": "row1"},
+                    {"sequence_number": 101, "data": "row2"},
+                ],
+                "partition_5",
             )
+        mock_channel.append_rows.assert_not_called()
 
-        with pytest.raises(RuntimeError, match="reported row errors"):
-            client._ingest_batch_impl(
-                "test_channel",
-                [{"sequence_number": 300, "data": "row1"}],
-                "partition_3",
-            )
-
-        assert client.streaming_client.get_channel_statuses.call_count == 2
-        assert client.stats["total_messages_sent"] == 0
-        assert client.stats["total_batches_sent"] == 0
-
-    def test_maybe_check_channel_status_throttles_per_channel(
+    def test_ingest_batch_impl_requires_sequence_number(
         self,
         sample_snowflake_config,
         sample_snowflake_connection_config,
+        mock_logfire,
+        mocker,
     ):
-        """Test channel status polling is throttled independently per channel."""
+        """Test that _ingest_batch_impl fails closed without source sequence numbers."""
         # Arrange
-        sample_snowflake_config.channel_status_interval_seconds = 60
+        client = SnowflakeHighPerformanceStreamingClient(
+            snowflake_config=sample_snowflake_config,
+            connection_config=sample_snowflake_connection_config,
+        )
+        mock_channel = MagicMock()
+        mock_channel.get_latest_committed_offset_token.return_value = None
+        mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
+
+        # Act & Assert
+        with pytest.raises(ValueError, match="sequence_number"):
+            client._ingest_batch_impl("test_channel", [{"data": "row1"}], "partition_0")
+        mock_channel.append_rows.assert_not_called()
+
+    def test_ingest_batch_impl_falls_back_to_append_row(
+        self,
+        sample_snowflake_config,
+        sample_snowflake_connection_config,
+        mock_logfire,
+        mocker,
+    ):
+        """Test that _ingest_batch_impl supports channels without append_rows."""
+        # Arrange
         client = SnowflakeHighPerformanceStreamingClient(
             snowflake_config=sample_snowflake_config,
             connection_config=sample_snowflake_connection_config,
         )
 
-        def make_status(channel_name: str) -> MagicMock:
-            status = MagicMock()
-            status.channel_name = channel_name
-            status.status_code = "OK"
-            status.rows_inserted_count = 0
-            status.rows_parsed_count = 0
-            status.rows_error_count = 0
-            status.last_error_message = None
-            status.last_error_timestamp = None
-            return status
+        class AppendRowOnlyChannel:
+            def __init__(self):
+                self.appended_rows = []
+                self.initiate_flush_called = False
 
-        client.streaming_client = MagicMock()
-        client.streaming_client.get_channel_statuses.side_effect = lambda names: {
-            names[0]: make_status(names[0])
-        }
+            def append_row(self, row, offset_token):
+                self.appended_rows.append((row, offset_token))
+
+            def initiate_flush(self):
+                self.initiate_flush_called = True
+
+            def wait_for_commit(self, token_checker, timeout_seconds=None):
+                assert token_checker(self.appended_rows[-1][1]) is True
+                assert timeout_seconds == sample_snowflake_config.connection_timeout_seconds
+
+            def get_latest_committed_offset_token(self):
+                return None
+
+        channel = AppendRowOnlyChannel()
+        mocker.patch.object(client, "_get_or_create_channel", return_value=channel)
+
+        data_batch = [
+            {"sequence_number": 1, "data": "row1"},
+            {"sequence_number": 2, "data": "row2"},
+        ]
 
         # Act
-        client._maybe_check_channel_status("channel-p0")
-        client._maybe_check_channel_status("channel-p1")
-        client._maybe_check_channel_status("channel-p0")
+        result = client._ingest_batch_impl("test_channel", data_batch, "partition_0")
 
         # Assert
-        assert client.streaming_client.get_channel_statuses.call_count == 2
-        client.streaming_client.get_channel_statuses.assert_any_call(["channel-p0"])
-        client.streaming_client.get_channel_statuses.assert_any_call(["channel-p1"])
+        assert result is True
+        assert channel.appended_rows == [
+            ({"sequence_number": 1, "data": "row1"}, "partition_0_1"),
+            ({"sequence_number": 2, "data": "row2"}, "partition_0_2"),
+        ]
+        assert channel.initiate_flush_called is True
+
+    def test_ingest_batch_impl_requires_commit_wait(
+        self,
+        sample_snowflake_config,
+        sample_snowflake_connection_config,
+        mock_logfire,
+        mocker,
+    ):
+        """Test that _ingest_batch_impl fails closed without wait_for_commit."""
+        # Arrange
+        client = SnowflakeHighPerformanceStreamingClient(
+            snowflake_config=sample_snowflake_config,
+            connection_config=sample_snowflake_connection_config,
+        )
+
+        class NoCommitWaitChannel:
+            def append_rows(self, rows, start_offset_token=None, end_offset_token=None):
+                return None
+
+            def initiate_flush(self):
+                return None
+
+            def get_latest_committed_offset_token(self):
+                return None
+
+        mocker.patch.object(client, "_get_or_create_channel", return_value=NoCommitWaitChannel())
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="wait_for_commit"):
+            client._ingest_batch_impl(
+                "test_channel",
+                [{"sequence_number": 1, "data": "row1"}],
+                "partition_0",
+            )
+
+    def test_ingest_batch_impl_fails_on_channel_status_row_errors(
+        self,
+        sample_snowflake_config,
+        sample_snowflake_connection_config,
+        mock_logfire,
+        mocker,
+    ):
+        """Test that _ingest_batch_impl fails when Snowflake reports row errors."""
+        # Arrange
+        client = SnowflakeHighPerformanceStreamingClient(
+            snowflake_config=sample_snowflake_config,
+            connection_config=sample_snowflake_connection_config,
+        )
+
+        mock_channel = MagicMock()
+        mock_channel.get_latest_committed_offset_token.return_value = None
+        mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
+
+        status = SimpleNamespace(
+            channel_name="test_channel",
+            status_code="ACTIVE",
+            rows_inserted_count=0,
+            rows_parsed_count=1,
+            rows_error_count=1,
+            last_error_message="bad row",
+            last_error_timestamp=None,
+            last_error_offset_token_upper_bound="partition_0_1",
+        )
+        client.streaming_client = MagicMock()
+        client.streaming_client.get_channel_statuses.return_value = {"test_channel": status}
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="reported row errors"):
+            client._ingest_batch_impl(
+                "test_channel",
+                [{"sequence_number": 1, "data": "row1"}],
+                "partition_0",
+            )
+
+    def test_ingest_batch_impl_fails_on_fatal_channel_status(
+        self,
+        sample_snowflake_config,
+        sample_snowflake_connection_config,
+        mock_logfire,
+        mocker,
+    ):
+        """Test that _ingest_batch_impl fails when Snowflake reports fatal status."""
+        # Arrange
+        client = SnowflakeHighPerformanceStreamingClient(
+            snowflake_config=sample_snowflake_config,
+            connection_config=sample_snowflake_connection_config,
+        )
+
+        mock_channel = MagicMock()
+        mock_channel.get_latest_committed_offset_token.return_value = None
+        mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
+        mocker.patch.object(client, "_reopen_channel")
+
+        status = SimpleNamespace(
+            channel_name="test_channel",
+            status_code="ERR_INVALID_CHANNEL",
+            rows_inserted_count=0,
+            rows_parsed_count=0,
+            rows_error_count=0,
+            last_error_message=None,
+            last_error_timestamp=None,
+            last_error_offset_token_upper_bound=None,
+        )
+        client.streaming_client = MagicMock()
+        client.streaming_client.get_channel_statuses.return_value = {"test_channel": status}
+
+        # Act & Assert
+        with pytest.raises(RuntimeError, match="status indicates an error"):
+            client._ingest_batch_impl(
+                "test_channel",
+                [{"sequence_number": 1, "data": "row1"}],
+                "partition_0",
+            )
 
     def test_ingest_batch_impl_with_empty_batch_returns_true(
         self,
@@ -939,7 +977,7 @@ class TestSnowflakeHighPerformanceStreamingClient:
         mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
 
         # Test data
-        data_batch = [{"data": "row1"}]
+        data_batch = [{"sequence_number": 1, "data": "row1"}]
 
         # Act & Assert
         with pytest.raises(Exception, match="Append failed"):
@@ -963,7 +1001,7 @@ class TestSnowflakeHighPerformanceStreamingClient:
         mocker.patch.object(client, "_get_or_create_channel", return_value=None)
 
         # Test data
-        data_batch = [{"data": "row1"}]
+        data_batch = [{"sequence_number": 1, "data": "row1"}]
 
         # Act & Assert
         with pytest.raises(RuntimeError, match="Failed to get channel"):
@@ -987,7 +1025,7 @@ class TestSnowflakeHighPerformanceStreamingClient:
         mock_impl = mocker.patch.object(client, "_ingest_with_retry", return_value=True)
 
         # Test data
-        data_batch = [{"data": "row1"}]
+        data_batch = [{"sequence_number": 1, "data": "row1"}]
 
         # Act
         result = client.ingest_batch("test_channel", data_batch, "partition_0")
@@ -1016,8 +1054,7 @@ class TestSnowflakeHighPerformanceStreamingClient:
         # Mock successful channel operation
         mock_channel = MagicMock()
         mock_channel.append_rows.return_value = None
-        mock_channel.get_latest_committed_offset_token.return_value = None
-        mock_channel.wait_for_commit.return_value = None
+        mock_channel.get_latest_committed_offset_token.return_value = "offset_123"
         mocker.patch.object(client, "_get_or_create_channel", return_value=mock_channel)
 
         # Store original implementation
@@ -1053,7 +1090,7 @@ class TestSnowflakeHighPerformanceStreamingClient:
         client._ingest_with_retry = retry_decorator(failing_impl)  # type: ignore[method-assign]
 
         # Test data
-        data_batch = [{"data": "row1"}]
+        data_batch = [{"sequence_number": 1, "data": "row1"}]
 
         # Act
         result = client.ingest_batch("test_channel", data_batch, "partition_0")

--- a/tests/unit/test_snowflake_utils.py
+++ b/tests/unit/test_snowflake_utils.py
@@ -863,3 +863,51 @@ class TestCheckpointOperations:
             )
 
         mock_snowflake_cursor.close.assert_called_once()
+
+
+class TestSnowflakeOwnershipUtilities:
+    """Tests for Snowflake ownership helper SQL."""
+
+    def test_ensure_ownership_table_uses_hybrid_table_primary_key(self, mock_snowflake_cursor):
+        """Test ownership table creation uses enforced Hybrid Table constraints."""
+        mock_snowflake_cursor.fetchall.side_effect = [[], []]
+
+        snowflake_utils._ensure_snowflake_ownership_table(
+            mock_snowflake_cursor,
+            "CONTROL.PUBLIC.INGESTION_STATUS_OWNERSHIP",
+        )
+
+        create_sql = mock_snowflake_cursor.execute.call_args_list[-1].args[0]
+        assert "CREATE HYBRID TABLE IF NOT EXISTS" in create_sql
+        assert "PRIMARY KEY" in create_sql
+
+    def test_ensure_ownership_table_rejects_existing_standard_table(self, mock_snowflake_cursor):
+        """Test existing non-hybrid ownership tables fail closed."""
+        mock_snowflake_cursor.fetchall.side_effect = [[], [("INGESTION_STATUS_OWNERSHIP",)]]
+
+        with pytest.raises(RuntimeError, match="not a Hybrid Table"):
+            snowflake_utils._ensure_snowflake_ownership_table(
+                mock_snowflake_cursor,
+                "CONTROL.PUBLIC.INGESTION_STATUS_OWNERSHIP",
+            )
+
+    def test_claim_ownership_validates_warehouse_identifier(self, snowflake_config):
+        """Test ownership claim validates config-driven warehouse identifiers."""
+        bad_config = snowflake_config.model_copy(update={"warehouse": "BAD;DROP"})
+
+        with pytest.raises(ValueError, match="Invalid Snowflake identifier"):
+            snowflake_utils.claim_partition_ownership(
+                ownership_list=[
+                    {
+                        "fully_qualified_namespace": "test.servicebus.windows.net",
+                        "eventhub_name": "test-hub",
+                        "consumer_group": "test-group",
+                        "partition_id": "0",
+                        "owner_id": "owner-1",
+                    }
+                ],
+                target_db="TEST_DB",
+                target_schema="TEST_SCHEMA",
+                target_table="TEST_TABLE",
+                config=bad_config,
+            )

--- a/tests/unit/test_snowflake_utils.py
+++ b/tests/unit/test_snowflake_utils.py
@@ -13,19 +13,18 @@ All tests use mocks and do not connect to real Snowflake instances.
 
 import json
 import re
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, patch, call
 from typing import Any
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.backends import default_backend
 
-from utils.config import SnowflakeConnectionConfig
 import utils.snowflake as snowflake_utils
-
+from utils.config import SnowflakeConnectionConfig
 
 # ============================================================================
 # Test Fixtures
@@ -569,6 +568,27 @@ class TestControlTable:
         assert "PARTITION_ID" in table_ddl_call
 
         mock_snowflake_connection.close.assert_called_once()
+
+    @patch("utils.snowflake.get_connection")
+    def test_create_control_table_can_create_standard_table(
+        self, mock_get_connection, mock_snowflake_connection, snowflake_config
+    ):
+        """Test standard control table creation for single-consumer smoke tests."""
+        mock_cursor = mock_snowflake_connection.cursor.return_value
+        mock_get_connection.return_value = mock_snowflake_connection
+
+        result = snowflake_utils.create_control_table(
+            target_db="CONTROL_DB",
+            target_schema="PUBLIC",
+            target_table="INGESTION_STATUS",
+            config=snowflake_config,
+            use_hybrid_table=False,
+        )
+
+        assert result is True
+        execute_calls = [call[0][0] for call in mock_cursor.execute.call_args_list]
+        assert any("CREATE TABLE IF NOT EXISTS" in call for call in execute_calls)
+        assert not any("CREATE HYBRID TABLE IF NOT EXISTS" in call for call in execute_calls)
 
     @patch("utils.snowflake.get_connection")
     def test_create_control_table_validates_identifiers(

--- a/tools/eventhub_sender/main.py
+++ b/tools/eventhub_sender/main.py
@@ -49,13 +49,16 @@ async def _build_producer(
     connection_string: str | None,
     namespace: str | None,
     eventhub: str,
-) -> EventHubProducerClient:
+) -> tuple[EventHubProducerClient, DefaultAzureCredential | None]:
     """Create an Event Hub producer using connection string or DefaultAzureCredential."""
     if connection_string:
         logger.info("Using connection string authentication")
-        return EventHubProducerClient.from_connection_string(
-            conn_str=connection_string,
-            eventhub_name=eventhub,
+        return (
+            EventHubProducerClient.from_connection_string(
+                conn_str=connection_string,
+                eventhub_name=eventhub,
+            ),
+            None,
         )
 
     if not namespace:
@@ -63,10 +66,13 @@ async def _build_producer(
 
     logger.info("Using DefaultAzureCredential for authentication")
     credential = DefaultAzureCredential()
-    return EventHubProducerClient(
-        fully_qualified_namespace=namespace,
-        eventhub_name=eventhub,
-        credential=credential,
+    return (
+        EventHubProducerClient(
+            fully_qualified_namespace=namespace,
+            eventhub_name=eventhub,
+            credential=credential,
+        ),
+        credential,
     )
 
 
@@ -174,64 +180,62 @@ async def send_messages(
         except Exception as err:
             raise typer.BadParameter(f"Invalid JSON for --payload: {err}") from err
 
-    producer = await _build_producer(connection_string, namespace, eventhub)
-    async with producer:
-        batch = await producer.create_batch(partition_key=partition_key)
-        batch_count = 0
-        sent = 0
-        sequence_id = start_id
-        start_time = time.time()
+    producer, credential = await _build_producer(connection_string, namespace, eventhub)
+    try:
+        async with producer:
+            await _send_messages_with_producer(
+                producer=producer,
+                count=count,
+                start_id=start_id,
+                batch_size=batch_size,
+                interval_seconds=interval_seconds,
+                max_messages_per_second=max_messages_per_second,
+                batch_pause_seconds=batch_pause_seconds,
+                max_retries=max_retries,
+                retry_base_delay_seconds=retry_base_delay_seconds,
+                retry_max_delay_seconds=retry_max_delay_seconds,
+                partition_key=partition_key,
+                base_payload=base_payload,
+            )
+    finally:
+        if credential is not None:
+            # Async Azure credentials own transport sessions; close them even when
+            # producer creation/send fails so local smoke tests do not leak aiohttp clients.
+            # https://learn.microsoft.com/python/api/azure-identity/azure.identity.aio.defaultazurecredential
+            await credential.close()
 
-        while sent < count:
-            message_body = _build_payload(sequence_id, base_payload)
-            event = EventData(message_body)
 
-            try:
-                batch.add(event)
-                batch_count += 1
-            except ValueError:
-                logger.info("Sending batch of %d messages", batch_count)
-                await _send_batch_with_retry(
-                    producer,
-                    batch,
-                    max_retries=max_retries,
-                    base_delay=retry_base_delay_seconds,
-                    max_delay=retry_max_delay_seconds,
-                )
-                if batch_pause_seconds > 0:
-                    await asyncio.sleep(batch_pause_seconds)
-                batch = await producer.create_batch(partition_key=partition_key)
-                batch.add(event)
-                batch_count = 1
+async def _send_messages_with_producer(
+    *,
+    producer: EventHubProducerClient,
+    count: int,
+    start_id: int,
+    batch_size: int,
+    interval_seconds: float,
+    max_messages_per_second: float,
+    batch_pause_seconds: float,
+    max_retries: int,
+    retry_base_delay_seconds: float,
+    retry_max_delay_seconds: float,
+    partition_key: str | None,
+    base_payload: dict[str, Any],
+) -> None:
+    """Send messages using an already-created producer."""
+    batch = await producer.create_batch(partition_key=partition_key)
+    batch_count = 0
+    sent = 0
+    sequence_id = start_id
+    start_time = time.time()
 
-            if batch_count >= batch_size:
-                logger.info("Sending batch of %d messages (size threshold)", batch_count)
-                await _send_batch_with_retry(
-                    producer,
-                    batch,
-                    max_retries=max_retries,
-                    base_delay=retry_base_delay_seconds,
-                    max_delay=retry_max_delay_seconds,
-                )
-                if batch_pause_seconds > 0:
-                    await asyncio.sleep(batch_pause_seconds)
-                batch = await producer.create_batch(partition_key=partition_key)
-                batch_count = 0
+    while sent < count:
+        message_body = _build_payload(sequence_id, base_payload)
+        event = EventData(message_body)
 
-            sent += 1
-            sequence_id += 1
-
-            if interval_seconds > 0:
-                await asyncio.sleep(interval_seconds)
-
-            if max_messages_per_second > 0:
-                target_time = start_time + (sent / max_messages_per_second)
-                now = time.time()
-                if target_time > now:
-                    await asyncio.sleep(target_time - now)
-
-        if batch_count > 0:
-            logger.info("Sending final batch of %d messages", batch_count)
+        try:
+            batch.add(event)
+            batch_count += 1
+        except ValueError:
+            logger.info("Sending batch of %d messages", batch_count)
             await _send_batch_with_retry(
                 producer,
                 batch,
@@ -241,9 +245,50 @@ async def send_messages(
             )
             if batch_pause_seconds > 0:
                 await asyncio.sleep(batch_pause_seconds)
+            batch = await producer.create_batch(partition_key=partition_key)
+            batch.add(event)
+            batch_count = 1
 
-        duration = time.time() - start_time
-        logger.info("Completed sending %d messages in %.2fs", sent, duration)
+        if batch_count >= batch_size:
+            logger.info("Sending batch of %d messages (size threshold)", batch_count)
+            await _send_batch_with_retry(
+                producer,
+                batch,
+                max_retries=max_retries,
+                base_delay=retry_base_delay_seconds,
+                max_delay=retry_max_delay_seconds,
+            )
+            if batch_pause_seconds > 0:
+                await asyncio.sleep(batch_pause_seconds)
+            batch = await producer.create_batch(partition_key=partition_key)
+            batch_count = 0
+
+        sent += 1
+        sequence_id += 1
+
+        if interval_seconds > 0:
+            await asyncio.sleep(interval_seconds)
+
+        if max_messages_per_second > 0:
+            target_time = start_time + (sent / max_messages_per_second)
+            now = time.time()
+            if target_time > now:
+                await asyncio.sleep(target_time - now)
+
+    if batch_count > 0:
+        logger.info("Sending final batch of %d messages", batch_count)
+        await _send_batch_with_retry(
+            producer,
+            batch,
+            max_retries=max_retries,
+            base_delay=retry_base_delay_seconds,
+            max_delay=retry_max_delay_seconds,
+        )
+        if batch_pause_seconds > 0:
+            await asyncio.sleep(batch_pause_seconds)
+
+    duration = time.time() - start_time
+    logger.info("Completed sending %d messages in %.2fs", sent, duration)
 
 
 @app.command()

--- a/uv.lock
+++ b/uv.lock
@@ -661,7 +661,7 @@ wheels = [
 
 [[package]]
 name = "evsnow"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- harden Event Hubs receiving, checkpoint timing, partition ownership handling, and Snowflake streaming shutdown
- add Snowflake standard-table single-consumer checkpoint smoke mode for local validation when Hybrid Tables are unavailable
- fix Postgres ownership DDL races and add release integration fixes on current `main`
- bump package metadata to `0.1.2`

## Validation
- `UV_PYTHON=3.13 uv run python -m py_compile src/utils/config.py src/utils/config_models/eventhub.py src/consumers/eventhub.py src/pipeline/orchestrator.py src/streaming/snowflake_high_performance.py src/main.py`
- `UV_PYTHON=3.13 uv run ruff check`
- `git diff --check`
- `UV_PYTHON=3.13 uv run pytest -q` -> 435 passed, 1 warning
- live normal run before release integration: started pipeline, sent 20 Event Hubs messages, verified Snowflake marker `normal-run-20260524185839` with 20 target rows and checkpoint rows for partitions 0 and 1

## Review Notes
- specialists agreed the final normal-run plan and Snowflake-backed validation before this release integration
- release branch was integrated on top of current `origin/main` to include #63 / CodSpeed changes
- secret hygiene checked: remaining connection-string examples are placeholders only
