### PR TITLE
[codex] Improve docs landing page and theme

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,20 +3,22 @@
 EvSnow streams events from Azure Event Hubs into Snowflake with checkpointing,
 configuration validation, and operational observability.
 
-Start with the first-run tutorial when you want one Event Hub, one Snowflake
-target, one checkpoint table, and a repeatable local smoke test.
+## Start With First Run
 
-```bash
-uv sync
-cp config/evsnow.example.toml config/evsnow.toml
-cp .env.example .env
-# Edit config/evsnow.toml and .env, then validate.
-uv run evsnow validate-config --config-file config/evsnow.toml --env-file .env
-```
+Start here when you want one Event Hub, one Snowflake target, one checkpoint
+table, and a repeatable local smoke test.
 
-Those commands install the project, create the editable runtime configuration,
-create an editable local environment file, and validate the resolved TOML plus
-environment values before the pipeline connects to Azure or Snowflake.
+Go to [First run](tutorial/first-run.md) to install EvSnow, configure one local
+pipeline, validate the settings, and run it.
+
+## Other Paths
+
+- Set up Snowflake from scratch: [Snowflake quickstart](getting-started/snowflake-quickstart.md)
+- Configure key-pair authentication: [Snowflake key-pair auth](snowflake/key-pair-auth.md)
+- Tune runtime settings: [Configuration](configuration.md)
+- Check every Snowflake object and grant: [Complete Snowflake setup](snowflake/complete-setup.md)
+- Inspect Iceberg data with DuckDB: [DuckDB Iceberg guide](how-to/query-iceberg-with-duckdb.md)
+- Run contributor checks: [Testing](development/testing.md)
 
 ## What EvSnow Connects
 
@@ -30,18 +32,8 @@ flowchart LR
 ```
 
 The Event Hub consumer reads from configured partitions. EvSnow writes data
-through Snowpipe Streaming and records progress in a control backend so later
-runs can resume from saved checkpoints.
-
-## Choose Your Path
-
-- New local run: [First run](tutorial/first-run.md)
-- Snowflake objects and grants: [Snowflake quickstart](getting-started/snowflake-quickstart.md)
-- Full configuration reference: [Configuration](configuration.md)
-- Full Snowflake setup reference: [Complete Snowflake setup](snowflake/complete-setup.md)
-- Key-pair authentication: [Snowflake key-pair auth](snowflake/key-pair-auth.md)
-- Query Iceberg tables from DuckDB: [DuckDB Iceberg guide](how-to/query-iceberg-with-duckdb.md)
-- Test and contributor workflow: [Testing](development/testing.md)
+through Snowpipe Streaming and records progress in a control backend. Later
+runs resume from saved checkpoints.
 
 ## Runtime Choices
 
@@ -58,24 +50,8 @@ The local tutorial uses a Snowflake standard table and
 `local_single_consumer_smoke`. Production deployments should use durable
 ownership with a Snowflake Hybrid Table or the Postgres control-table backend.
 
-## Documentation Map
+## After First Run
 
-The docs are organized like a FastAPI-style guide:
-
-- Tutorial pages show the smallest complete path first.
-- Setup pages explain required configuration and Snowflake objects.
-- How-to pages solve focused operational tasks.
-- Reference pages collect full configuration and object details.
-- Development pages cover tests, workflows, and contributor notes.
-- Archive pages preserve implementation plans and historical hardening notes.
-
-## Build These Docs
-
-```bash
-uv sync --group docs
-uv run zensical build --clean --strict
-uv run zensical serve
-```
-
-The generated static site is written to `site/`. GitHub Pages deploys that
-directory from the documentation workflow after changes land on `main`.
+Use the Snowflake setup pages when you need to create or audit account objects.
+Use the configuration reference when you are changing pipeline behavior. Use the
+how-to guides for operational tasks after the first pipeline works.

--- a/zensical.toml
+++ b/zensical.toml
@@ -54,18 +54,36 @@ nav = [
 ]
 
 [project.theme]
+variant = "modern"
 features = [
   "content.action.edit",
   "content.action.view",
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.tabs",
+  "navigation.tabs.sticky",
   "navigation.sections",
   "navigation.path",
   "navigation.tracking",
   "navigation.top",
   "toc.follow"
 ]
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: light)"
+scheme = "default"
+primary = "teal"
+accent = "cyan"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+media = "(prefers-color-scheme: dark)"
+scheme = "slate"
+primary = "teal"
+accent = "cyan"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
 
 [project.theme.icon]
 repo = "fontawesome/brands/github"


### PR DESCRIPTION
## Summary
- make the docs landing page start with First run as the primary path
- remove maintainer-focused build-docs instructions from the user landing page
- add a modern Zensical theme treatment with sticky tabs and light/dark teal palettes

## Validation
- `uv run zensical build --clean --strict`
- `git diff --check`
- `uv lock --check`
