### PR TITLE
Improve Snowflake quickstart validation docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,4 +210,6 @@ __marimo__/
 .env.test
 AZURE_OPENAI_PROGRESS.md
 /snowflake/
+.quickstart/
+.quickstart-runs/
 .testenv

--- a/docs/getting-started/snowflake-quickstart.md
+++ b/docs/getting-started/snowflake-quickstart.md
@@ -1,91 +1,132 @@
 # Snowflake Quickstart
 
 Use this page when the Snowflake objects for the first run do not exist yet.
-It creates the runtime role, service user, control table, target table, and
-Snowpipe Streaming pipe.
+It creates the runtime role, service user, warehouse, control table, target
+table, and Snowpipe Streaming pipe.
+
+## Before You Start
+
+You need an active Snowflake account and a setup role that can create users,
+roles, warehouses, databases, schemas, tables, pipes, and grants. `ACCOUNTADMIN`
+is acceptable for a one-time bootstrap when your organization does not provide a
+narrower setup role.
+
+If `snow connection test` succeeds but object creation fails with
+`000666 ... account is suspended due to lack of payment method`, reactivate the
+Snowflake account before retrying. A successful login does not prove the account
+can run setup DDL.
+
+The commands below use the Snowflake CLI:
+
+```bash
+snow connection test --connection <setup-connection>
+```
+
+You can also run the same SQL in Snowflake Worksheets. Replace
+`<setup-connection>` with the connection name for your setup role.
 
 ## Generate The RSA Key
+
+For an interactive local setup, run:
 
 ```bash
 ./generate_snowflake_keys.sh
 ```
 
-The script creates an encrypted private key and prints the public key value.
-Keep the private key outside Git.
+The script creates:
 
-## Create The Runtime User
+| File | Purpose |
+|------|---------|
+| `snowflake/rsa_key_encrypted.p8` | Encrypted private key used by EvSnow |
+| `snowflake/rsa_key_pub.pem` | Public key file |
+| `snowflake/rsa_key_pub_value.txt` | Public key value to paste into Snowflake SQL |
 
-Run this in Snowflake with a setup role that can create roles, users,
-databases, schemas, tables, and pipes:
-
-```sql
-USE ROLE ACCOUNTADMIN;
-
-CREATE ROLE IF NOT EXISTS STREAM;
-CREATE USER IF NOT EXISTS STREAMEV
-  DEFAULT_ROLE = STREAM
-  DEFAULT_WAREHOUSE = COMPUTE_WH;
-
-GRANT ROLE STREAM TO USER STREAMEV;
-ALTER USER STREAMEV SET RSA_PUBLIC_KEY = '<PUBLIC_KEY_FROM_SCRIPT>';
-```
-
-Use `ACCOUNTADMIN` only for this one-time bootstrap if your organization does
-not provide a narrower setup role. Runtime ingestion should use the `STREAM`
-role or another least-privilege role.
-
-## Create Databases And Schemas
-
-```sql
-CREATE DATABASE IF NOT EXISTS INGESTION;
-CREATE SCHEMA IF NOT EXISTS INGESTION.PUBLIC;
-
-CREATE DATABASE IF NOT EXISTS CONTROL;
-CREATE SCHEMA IF NOT EXISTS CONTROL.PUBLIC;
-
-GRANT USAGE ON DATABASE INGESTION TO ROLE STREAM;
-GRANT USAGE ON SCHEMA INGESTION.PUBLIC TO ROLE STREAM;
-GRANT USAGE ON DATABASE CONTROL TO ROLE STREAM;
-GRANT USAGE ON SCHEMA CONTROL.PUBLIC TO ROLE STREAM;
-```
-
-These objects match the defaults used in the first-run tutorial.
-
-## Create The Control Table And Grants
+For headless validation or CI, provide the password through
+`EVSNOW_KEY_PASSWORD`:
 
 ```bash
-# Open setup_snowflake.sql in Snowflake Worksheets or SnowSQL.
-# Replace <PUBLIC_KEY_VALUE> with the value from generate_snowflake_keys.sh.
+EVSNOW_KEY_PASSWORD="replace-with-key-password" ./generate_snowflake_keys.sh
 ```
 
-Run the checked-in
-[`setup_snowflake.sql`](https://github.com/MiguelElGallo/evsnow/blob/main/setup_snowflake.sql).
-It creates the exact `CONTROL.PUBLIC.INGESTION_STATUS` schema used by EvSnow:
-`EVENTHUB_NAMESPACE`, `EVENTHUB`, target database/schema/table, `WATERLEVEL`,
-`PARTITION_ID`, and `METADATA`.
+Do not pipe the password into the script. Keep the encrypted private key and the
+password outside Git. The script does not write an unencrypted private key unless
+you explicitly set `EVSNOW_WRITE_UNENCRYPTED_KEY=yes`.
+
+## Run The Snowflake Bootstrap
+
+Render `setup_snowflake.sql` with the generated public key, then run it with the
+setup connection:
+
+```bash
+mkdir -p .quickstart
+PUBLIC_KEY_VALUE="$(tr -d '\n' < snowflake/rsa_key_pub_value.txt)"
+sed "s|<PUBLIC_KEY_VALUE>|${PUBLIC_KEY_VALUE}|g" \
+  setup_snowflake.sql > .quickstart/setup_snowflake.sql
+
+snow sql \
+  --connection <setup-connection> \
+  --filename .quickstart/setup_snowflake.sql
+```
+
+The script creates or verifies:
+
+| Object | Default |
+|--------|---------|
+| Runtime role | `STREAM` |
+| Runtime user | `STREAMEV` |
+| Warehouse | `COMPUTE_WH` |
+| Ingestion database/schema | `INGESTION.PUBLIC` |
+| Control database/schema/table | `CONTROL.PUBLIC.INGESTION_STATUS` |
+
+It also grants the `STREAM` role the privileges needed by the runtime.
 
 ## Create The Target Table And Pipe
 
+Run the Snowpipe Streaming setup script:
+
 ```bash
-# Open setup_snowpipe_streaming.sql in Snowflake Worksheets or SnowSQL.
+snow sql \
+  --connection <setup-connection> \
+  --filename setup_snowpipe_streaming.sql
 ```
 
-Run the checked-in
-[`setup_snowpipe_streaming.sql`](https://github.com/MiguelElGallo/evsnow/blob/main/setup_snowpipe_streaming.sql).
-It creates the Snowflake-managed Iceberg table and the required high-performance
-Snowpipe Streaming pipe with `DATA_SOURCE(TYPE => 'STREAMING')`.
+The script creates the Snowflake-managed Iceberg target table and the
+high-performance Snowpipe Streaming pipe if they do not already exist:
 
-The table definition uses Snowflake-managed Iceberg storage by default:
+| Object | Default |
+|--------|---------|
+| Target table | `INGESTION.PUBLIC.EVENTS_TABLE1` |
+| Streaming pipe | `INGESTION.PUBLIC.EVENTS_TABLE_PIPE` |
+
+The table uses Snowflake-managed Iceberg storage:
 
 ```sql
-CREATE OR REPLACE ICEBERG TABLE INGESTION.PUBLIC.EVENTS_TABLE1
+CREATE ICEBERG TABLE IF NOT EXISTS INGESTION.PUBLIC.EVENTS_TABLE1
   CATALOG = SNOWFLAKE
   EXTERNAL_VOLUME = SNOWFLAKE_MANAGED
   ICEBERG_VERSION = 3;
 ```
 
-Use [Complete Snowflake setup](../snowflake/complete-setup.md) if you need the
-long-form object reference or troubleshooting notes.
+Use [Complete Snowflake setup](../snowflake/complete-setup.md) for the long-form
+object reference.
+
+## Verify Snowflake Objects
+
+Run these checks with the setup connection:
+
+```bash
+snow sql --connection <setup-connection> --query "
+DESC USER STREAMEV;
+SHOW GRANTS TO ROLE STREAM;
+DESC TABLE CONTROL.PUBLIC.INGESTION_STATUS;
+DESC TABLE INGESTION.PUBLIC.EVENTS_TABLE1;
+SHOW PIPES LIKE 'EVENTS_TABLE_PIPE' IN SCHEMA INGESTION.PUBLIC;
+SHOW GRANTS ON PIPE INGESTION.PUBLIC.EVENTS_TABLE_PIPE;
+"
+```
+
+The pipe check must return `EVENTS_TABLE_PIPE`, and the grant checks must show
+the runtime role has table access plus `OPERATE` and `MONITOR` on the pipe.
 
 ## Configure EvSnow
 
@@ -106,11 +147,13 @@ batch_size = 100
 Create `.env` with only secrets and local credentials:
 
 ```bash
-SNOWFLAKE_ACCOUNT=<account_locator>.<region>
+SNOWFLAKE_ACCOUNT=<account_locator>
 SNOWFLAKE_USER=STREAMEV
 SNOWFLAKE_PRIVATE_KEY_FILE=snowflake/rsa_key_encrypted.p8
 SNOWFLAKE_PRIVATE_KEY_PASSWORD=<key-password>
 SNOWFLAKE_WAREHOUSE=COMPUTE_WH
+SNOWFLAKE_DATABASE=INGESTION
+SNOWFLAKE_SCHEMA_NAME=PUBLIC
 SNOWFLAKE_ROLE=STREAM
 SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
 ```
@@ -118,10 +161,14 @@ SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
 The full environment template remains in
 [`.env.example`](https://github.com/MiguelElGallo/evsnow/blob/main/.env.example).
 
-## Verify
+## Verify EvSnow Configuration
 
 ```bash
 uv run evsnow validate-config --config-file config/evsnow.toml --env-file .env
 ```
+
+This validates the resolved EvSnow configuration and control-table access. Keep
+the Snowflake object checks above as the proof that the Iceberg table, pipe, and
+pipe grants exist.
 
 After validation passes, continue with [First run](../tutorial/first-run.md).

--- a/docs/snowflake/complete-setup.md
+++ b/docs/snowflake/complete-setup.md
@@ -1,9 +1,10 @@
 # Complete Snowflake Setup
 
 This reference collects the Snowflake objects EvSnow needs. New users should
-start with [First run](../tutorial/first-run.md), then use
-[Snowflake quickstart](../getting-started/snowflake-quickstart.md) when the
-Snowflake objects do not exist yet.
+start with [First run](../tutorial/first-run.md) to understand the runtime flow.
+If the Snowflake objects do not already exist, complete
+[Snowflake quickstart](../getting-started/snowflake-quickstart.md) before
+running the pipeline.
 
 ## Object Map
 
@@ -11,6 +12,7 @@ Snowflake objects do not exist yet.
 |--------|--------------|---------|
 | Runtime role | `STREAM` | Least-privilege role used by EvSnow |
 | Runtime user | `STREAMEV` | Key-pair authenticated service user |
+| Warehouse | `COMPUTE_WH` | Runtime warehouse used for validation and setup |
 | Ingestion database | `INGESTION` | Target database for streamed events |
 | Ingestion schema | `PUBLIC` | Target schema for the first-run example |
 | Control database | `CONTROL` | Checkpoint database |
@@ -22,18 +24,22 @@ Snowflake objects do not exist yet.
 
 Use the checked-in scripts as the source of truth:
 
-- [`setup_snowflake.sql`](https://github.com/MiguelElGallo/evsnow/blob/main/setup_snowflake.sql) creates the role, user key assignment, databases, schemas, control table, and grants.
-- [`setup_snowpipe_streaming.sql`](https://github.com/MiguelElGallo/evsnow/blob/main/setup_snowpipe_streaming.sql) creates the Snowflake-managed Iceberg table and pipe with `DATA_SOURCE(TYPE => 'STREAMING')`.
+- [`setup_snowflake.sql`](https://github.com/MiguelElGallo/evsnow/blob/main/setup_snowflake.sql) creates the role, user key assignment, warehouse, databases, schemas, control table, and grants.
+- [`setup_snowpipe_streaming.sql`](https://github.com/MiguelElGallo/evsnow/blob/main/setup_snowpipe_streaming.sql) creates the Snowflake-managed Iceberg table and pipe with `DATA_SOURCE(TYPE => 'STREAMING')` if they do not already exist.
 
-Run the scripts in Snowflake Worksheets or SnowSQL with a setup role that can
-create users, roles, databases, schemas, tables, pipes, and grants. Use
-`ACCOUNTADMIN` only for one-time bootstrap when your organization does not
-provide a narrower setup role.
+Run the scripts in Snowflake Worksheets or with the Snowflake CLI using a setup
+role that can create users, roles, databases, schemas, tables, pipes, and
+grants. Use `ACCOUNTADMIN` only for one-time bootstrap when your organization
+does not provide a narrower setup role.
+
+If Snowflake returns `000666 ... account is suspended due to lack of payment
+method`, the account can authenticate but cannot run setup DDL. Reactivate the
+account and rerun the setup script.
 
 The default setup keeps Iceberg storage Snowflake-managed:
 
 ```sql
-CREATE OR REPLACE ICEBERG TABLE INGESTION.PUBLIC.EVENTS_TABLE1
+CREATE ICEBERG TABLE IF NOT EXISTS INGESTION.PUBLIC.EVENTS_TABLE1
   CATALOG = SNOWFLAKE
   EXTERNAL_VOLUME = SNOWFLAKE_MANAGED
   ICEBERG_VERSION = 3;
@@ -75,6 +81,8 @@ SNOWFLAKE_USER=STREAMEV
 SNOWFLAKE_PRIVATE_KEY_FILE=snowflake/rsa_key_encrypted.p8
 SNOWFLAKE_PRIVATE_KEY_PASSWORD=<key-password>
 SNOWFLAKE_WAREHOUSE=COMPUTE_WH
+SNOWFLAKE_DATABASE=INGESTION
+SNOWFLAKE_SCHEMA_NAME=PUBLIC
 SNOWFLAKE_ROLE=STREAM
 SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
 ```
@@ -128,3 +136,12 @@ SHOW GRANTS ON TABLE CONTROL.PUBLIC.INGESTION_STATUS;
 
 The table schema must match `setup_snowflake.sql`, and the runtime role needs
 `SELECT`, `INSERT`, and `UPDATE` privileges.
+
+### Account Suspended
+
+```text
+000666 (57014): Your account is suspended due to lack of payment method.
+```
+
+Fix the Snowflake account billing/reactivation state first. Connection tests can
+still pass while create/drop/alter statements are blocked.

--- a/docs/snowflake/key-pair-auth.md
+++ b/docs/snowflake/key-pair-auth.md
@@ -10,6 +10,18 @@ Set up key-pair authentication for EvSnow using RSA keys (JWT).
 
 ## 1) Generate RSA keys (PKCS#8, encrypted)
 
+The repo helper creates the encrypted private key and public key value used by
+the quickstart:
+
+```bash
+./generate_snowflake_keys.sh
+```
+
+For headless validation, set `EVSNOW_KEY_PASSWORD` instead of piping a password
+to OpenSSL.
+
+Manual equivalent:
+
 ```bash
 # Encrypted private key (recommended) - uses DES3 like generate_snowflake_keys.sh
 openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM -out rsa_key_encrypted.p8 -v2 des3
@@ -42,7 +54,7 @@ snow connection test \
   --account <account_identifier> \
   --user <username> \
   --authenticator SNOWFLAKE_JWT \
-  --private-key-path rsa_key_encrypted.p8
+  --private-key-file rsa_key_encrypted.p8
 ```
 
 Private-key authentication requires `SNOWFLAKE_JWT`. EvSnow uses the same key

--- a/docs/tutorial/first-run.md
+++ b/docs/tutorial/first-run.md
@@ -3,6 +3,11 @@
 This tutorial runs one Event Hub into one Snowflake target with one checkpoint
 table. It keeps pipeline shape in TOML and keeps secrets in `.env`.
 
+Fresh Snowflake accounts should complete
+[Snowflake quickstart](../getting-started/snowflake-quickstart.md) first. This
+tutorial assumes the `STREAM` role, `STREAMEV` user, `CONTROL` database,
+`INGESTION` database, target Iceberg table, and streaming pipe already exist.
+
 ## Install
 
 ```bash
@@ -59,19 +64,16 @@ first smoke test. `EVENTHUBNAME_1` and `SNOWFLAKE_1` are local mapping keys.
 
 ## Create `.env`
 
-```bash
-./generate_snowflake_keys.sh
-```
-
-Run the printed `ALTER USER` SQL in Snowflake with a role allowed to alter the
-target user. Then create `.env`:
+Use the encrypted key created during Snowflake setup, then create `.env`:
 
 ```bash
 SNOWFLAKE_ACCOUNT=aaaaaa-bbbbbbb
 SNOWFLAKE_USER=STREAMEV
 SNOWFLAKE_PRIVATE_KEY_FILE=snowflake/rsa_key_encrypted.p8
 SNOWFLAKE_PRIVATE_KEY_PASSWORD=your-password
-SNOWFLAKE_WAREHOUSE=compute_wh
+SNOWFLAKE_WAREHOUSE=COMPUTE_WH
+SNOWFLAKE_DATABASE=INGESTION
+SNOWFLAKE_SCHEMA_NAME=PUBLIC
 SNOWFLAKE_ROLE=STREAM
 SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
 ```
@@ -145,5 +147,5 @@ offsets and ignore `starting_position_on_no_checkpoint`.
 
 - Use [Configuration](../configuration.md) for the full TOML and `.env` reference.
 - Use [Snowflake key-pair auth](../snowflake/key-pair-auth.md) to troubleshoot RSA authentication.
-- Use [Snowflake quickstart](../getting-started/snowflake-quickstart.md) when the target database, pipe, or grants do not exist yet.
+- Use [Snowflake quickstart](../getting-started/snowflake-quickstart.md) when the runtime user, target database, pipe, or grants do not exist yet.
 - Use [Event Hub sender](../tools/eventhub-sender.md) for repeatable local message sends.

--- a/generate_snowflake_keys.sh
+++ b/generate_snowflake_keys.sh
@@ -28,24 +28,65 @@ if [ -f "rsa_key_encrypted.p8" ]; then
 fi
 
 echo "Step 1: Generating RSA private key (2048-bit) and encrypting with DES3..."
-echo "You will be prompted to enter a password (twice)."
-echo "⚠️  IMPORTANT: Remember this password - you'll need it for SNOWFLAKE_PRIVATE_KEY_PASSWORD"
-# Using des3 as per Snowflake official documentation:
-# https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-keys
-openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 des3 -inform PEM -out rsa_key_encrypted.p8
+if [ -n "${EVSNOW_KEY_PASSWORD:-}" ]; then
+    echo "Using EVSNOW_KEY_PASSWORD for non-interactive key generation."
+    echo "⚠️  IMPORTANT: Store this password - you'll need it for SNOWFLAKE_PRIVATE_KEY_PASSWORD"
+    # Using des3 as per Snowflake official documentation:
+    # https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-keys
+    openssl genrsa 2048 | openssl pkcs8 \
+        -topk8 \
+        -v2 des3 \
+        -inform PEM \
+        -out rsa_key_encrypted.p8 \
+        -passout "pass:${EVSNOW_KEY_PASSWORD}"
+else
+    echo "You will be prompted to enter a password (twice)."
+    echo "⚠️  IMPORTANT: Remember this password - you'll need it for SNOWFLAKE_PRIVATE_KEY_PASSWORD"
+    # Using des3 as per Snowflake official documentation:
+    # https://docs.snowflake.com/en/user-guide/key-pair-auth#generate-the-private-keys
+    openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 des3 -inform PEM -out rsa_key_encrypted.p8
+fi
 
 echo ""
-echo "Step 2: Creating unencrypted backup copy..."
-openssl pkcs8 -topk8 -inform PEM -in rsa_key_encrypted.p8 -out rsa_key.pem -nocrypt 2>/dev/null || \
-    openssl rsa -in rsa_key_encrypted.p8 -out rsa_key.pem 2>/dev/null
+echo "Step 2: Optional unencrypted backup copy..."
+if [ "${EVSNOW_WRITE_UNENCRYPTED_KEY:-}" = "yes" ]; then
+    if [ -n "${EVSNOW_KEY_PASSWORD:-}" ]; then
+        openssl pkcs8 \
+            -topk8 \
+            -inform PEM \
+            -in rsa_key_encrypted.p8 \
+            -out rsa_key.pem \
+            -nocrypt \
+            -passin "pass:${EVSNOW_KEY_PASSWORD}" 2>/dev/null || \
+            openssl rsa \
+                -in rsa_key_encrypted.p8 \
+                -out rsa_key.pem \
+                -passin "pass:${EVSNOW_KEY_PASSWORD}" 2>/dev/null
+    else
+        openssl pkcs8 -topk8 -inform PEM -in rsa_key_encrypted.p8 -out rsa_key.pem -nocrypt 2>/dev/null || \
+            openssl rsa -in rsa_key_encrypted.p8 -out rsa_key.pem 2>/dev/null
+    fi
+else
+    echo "Skipping unencrypted backup. Set EVSNOW_WRITE_UNENCRYPTED_KEY=yes if you explicitly need rsa_key.pem."
+fi
 
 echo ""
 echo "Step 3: Setting secure file permissions..."
 chmod 600 rsa_key_encrypted.p8
-chmod 600 rsa_key.pem
+if [ -f "rsa_key.pem" ]; then
+    chmod 600 rsa_key.pem
+fi
 
 echo "Step 4: Extracting public key..."
-openssl rsa -in rsa_key_encrypted.p8 -pubout -out rsa_key_pub.pem
+if [ -n "${EVSNOW_KEY_PASSWORD:-}" ]; then
+    openssl rsa \
+        -in rsa_key_encrypted.p8 \
+        -pubout \
+        -out rsa_key_pub.pem \
+        -passin "pass:${EVSNOW_KEY_PASSWORD}"
+else
+    openssl rsa -in rsa_key_encrypted.p8 -pubout -out rsa_key_pub.pem
+fi
 
 echo "Step 5: Preparing public key value for Snowflake..."
 grep -v "BEGIN PUBLIC" rsa_key_pub.pem | grep -v "END PUBLIC" | tr -d '\n' > rsa_key_pub_value.txt
@@ -55,10 +96,12 @@ echo ""
 echo "✅ Keys generated successfully!"
 echo ""
 echo "Files created in snowflake/ directory:"
-echo "  - rsa_key.pem (unencrypted private key - for backup only)"
 echo "  - rsa_key_encrypted.p8 (encrypted private key - USE THIS)"
 echo "  - rsa_key_pub.pem (public key file)"
 echo "  - rsa_key_pub_value.txt (public key value for Snowflake)"
+if [ -f "rsa_key.pem" ]; then
+    echo "  - rsa_key.pem (unencrypted private key - backup only)"
+fi
 echo ""
 echo "=========================================="
 echo "NEXT STEPS:"

--- a/setup_snowflake.sql
+++ b/setup_snowflake.sql
@@ -1,9 +1,9 @@
 -- Snowflake Setup SQL Script
--- Run this script in Snowflake Web UI (Worksheets) or SnowSQL
+-- Run this script in Snowflake Web UI (Worksheets) or the Snowflake CLI
 -- Make sure you're logged in as a user with appropriate permissions (ACCOUNTADMIN or similar)
 
 -- ============================================
--- PART 1: Assign RSA Public Key to User
+-- PART 1: Create Runtime Role, Warehouse, And User
 -- ============================================
 
 -- Read the public key value from: snowflake/rsa_key_pub_value.txt
@@ -11,19 +11,26 @@
 
 USE ROLE ACCOUNTADMIN;  -- Or your admin role
 
+CREATE ROLE IF NOT EXISTS STREAM;
+
+CREATE WAREHOUSE IF NOT EXISTS COMPUTE_WH
+    WAREHOUSE_SIZE = XSMALL
+    AUTO_SUSPEND = 300
+    AUTO_RESUME = TRUE
+    INITIALLY_SUSPENDED = TRUE;
+
+CREATE USER IF NOT EXISTS STREAMEV
+    DEFAULT_ROLE = STREAM
+    DEFAULT_WAREHOUSE = COMPUTE_WH
+    RSA_PUBLIC_KEY = '<PUBLIC_KEY_VALUE>';
+
+GRANT ROLE STREAM TO USER STREAMEV;
 ALTER USER STREAMEV SET RSA_PUBLIC_KEY='<PUBLIC_KEY_VALUE>';
 
 -- Verify the key was set:
 DESC USER STREAMEV;
 -- Look for RSA_PUBLIC_KEY_FP (fingerprint) - should not be NULL
 
-
--- ============================================
--- PART 2: Create INGESTION Database and Schema
--- ============================================
-
-CREATE ROLE IF NOT EXISTS STREAM;
-GRANT ROLE STREAM TO USER STREAMEV;
 
 CREATE DATABASE IF NOT EXISTS INGESTION;
 
@@ -106,6 +113,9 @@ GRANT INSERT, SELECT ON FUTURE TABLES IN SCHEMA INGESTION.PUBLIC TO ROLE STREAM;
 
 -- Check RSA public key
 DESC USER STREAMEV;
+
+-- Check runtime role grants
+SHOW GRANTS TO ROLE STREAM;
 
 -- Check databases
 SHOW DATABASES LIKE 'INGESTION';

--- a/setup_snowpipe_streaming.sql
+++ b/setup_snowpipe_streaming.sql
@@ -1,6 +1,8 @@
 -- ============================================================================
 -- SNOWPIPE STREAMING HIGH-PERFORMANCE ARCHITECTURE SETUP
--- Run this in Snowflake to create the required Iceberg table and PIPE
+-- Run this in Snowflake to create the required Iceberg table and PIPE.
+-- The CREATE statements use IF NOT EXISTS so the quickstart does not replace
+-- an existing target table or pipe.
 --
 -- References:
 --   https://docs.snowflake.com/en/user-guide/tables-iceberg-internal-storage
@@ -30,7 +32,7 @@ USE WAREHOUSE COMPUTE_WH;
 -- Do not create EXVOL, grant external-volume privileges, or set a table base path
 -- for the default setup.
 -- ============================================================================
-CREATE OR REPLACE ICEBERG TABLE INGESTION.PUBLIC.EVENTS_TABLE1 (
+CREATE ICEBERG TABLE IF NOT EXISTS INGESTION.PUBLIC.EVENTS_TABLE1 (
     EVENT_BODY STRING,
     PARTITION_ID STRING,
     SEQUENCE_NUMBER DECIMAL(38, 0),
@@ -54,7 +56,7 @@ ICEBERG_VERSION = 3;
 -- EvSnow splits mixed-partition Event Hub batches before ingest, so each
 -- Snowpipe Streaming channel receives only one partition in sequence order.
 -- ============================================================================
-CREATE OR REPLACE PIPE INGESTION.PUBLIC.EVENTS_TABLE_PIPE AS
+CREATE PIPE IF NOT EXISTS INGESTION.PUBLIC.EVENTS_TABLE_PIPE AS
 COPY INTO INGESTION.PUBLIC.EVENTS_TABLE1 (
     EVENT_BODY,
     PARTITION_ID,

--- a/tests/unit/test_snowflake_internal_iceberg_setup.py
+++ b/tests/unit/test_snowflake_internal_iceberg_setup.py
@@ -18,11 +18,11 @@ def _normalized(path: Path) -> str:
 def test_streaming_setup_uses_internal_snowflake_managed_iceberg():
     sql = _normalized(SETUP_SQL)
 
-    assert "CREATE OR REPLACE ICEBERG TABLE INGESTION.PUBLIC.EVENTS_TABLE1" in sql
+    assert "CREATE ICEBERG TABLE IF NOT EXISTS INGESTION.PUBLIC.EVENTS_TABLE1" in sql
     assert "CATALOG = SNOWFLAKE" in sql
     assert "EXTERNAL_VOLUME = SNOWFLAKE_MANAGED" in sql
     assert "ICEBERG_VERSION = 3" in sql
-    assert "CREATE OR REPLACE PIPE INGESTION.PUBLIC.EVENTS_TABLE_PIPE" in sql
+    assert "CREATE PIPE IF NOT EXISTS INGESTION.PUBLIC.EVENTS_TABLE_PIPE" in sql
     assert "INGESTION_TIMESTAMP" in sql
     assert "CURRENT_TIMESTAMP()::TIMESTAMP_LTZ(6) AS INGESTION_TIMESTAMP" in sql
     assert "DATA_SOURCE(TYPE => 'STREAMING')" in sql

--- a/tools/quickstart_harness.py
+++ b/tools/quickstart_harness.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Run the Snowflake quickstart with command/output logging.
+
+The harness intentionally runs in a scratch copy of the repository so generated
+keys, config files, and .env content do not modify the working tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONNECTION = "automa_zfelfof_nfa14829"
+DEFAULT_RUN_ROOT = REPO_ROOT / ".quickstart-runs"
+
+
+@dataclass
+class CommandResult:
+    name: str
+    command: str
+    cwd: str
+    exit_code: int
+    stdout: str
+    stderr: str
+    started_at: str
+    ended_at: str
+
+
+class Harness:
+    def __init__(self, *, connection: str, run_root: Path, keep_going: bool) -> None:
+        timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        self.run_dir = run_root / timestamp
+        self.workspace = self.run_dir / "workspace"
+        self.log_path = self.run_dir / "commands.jsonl"
+        self.summary_path = self.run_dir / "summary.json"
+        self.connection = connection
+        self.keep_going = keep_going
+        self.redactions: dict[str, str] = {}
+        self.results: list[CommandResult] = []
+        self.failed = False
+
+    def prepare(self) -> None:
+        self.run_dir.mkdir(parents=True, exist_ok=False)
+        shutil.copytree(
+            REPO_ROOT,
+            self.workspace,
+            ignore=shutil.ignore_patterns(
+                ".git",
+                ".venv",
+                "site",
+                ".quickstart-runs",
+                ".cache",
+                ".pytest_cache",
+                ".ruff_cache",
+                "__pycache__",
+                "snowflake",
+            ),
+        )
+
+    def redact(self, value: str) -> str:
+        redacted = value
+        for secret, replacement in self.redactions.items():
+            if secret:
+                redacted = redacted.replace(secret, replacement)
+        return redacted
+
+    def record(self, result: CommandResult) -> None:
+        self.results.append(result)
+        self.write_log()
+
+    def write_log(self) -> None:
+        with self.log_path.open("w", encoding="utf-8") as handle:
+            for result in self.results:
+                payload = self.result_payload(result)
+                handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+
+    def record_existing_redactions(self) -> None:
+        if self.results:
+            self.write_log()
+
+    def result_payload(self, result: CommandResult) -> dict[str, Any]:
+        payload = {
+            "name": result.name,
+            "command": self.redact(result.command),
+            "cwd": result.cwd,
+            "exit_code": result.exit_code,
+            "stdout": self.redact(result.stdout),
+            "stderr": self.redact(result.stderr),
+            "started_at": result.started_at,
+            "ended_at": result.ended_at,
+        }
+        return payload
+
+    def run(
+        self,
+        name: str,
+        command: list[str],
+        *,
+        cwd: Path | None = None,
+        stdin: str | None = None,
+        display_command: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: int = 180,
+    ) -> CommandResult:
+        cwd = cwd or self.workspace
+        started_at = datetime.now(UTC).isoformat()
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            input=stdin,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env={**os.environ, **(env or {})},
+            check=False,
+        )
+        ended_at = datetime.now(UTC).isoformat()
+        result = CommandResult(
+            name=name,
+            command=display_command or " ".join(command),
+            cwd=str(cwd),
+            exit_code=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            started_at=started_at,
+            ended_at=ended_at,
+        )
+        self.record(result)
+        if completed.returncode != 0:
+            self.failed = True
+            if not self.keep_going:
+                self.write_summary()
+                raise SystemExit(completed.returncode)
+        return result
+
+    def note(self, name: str, message: str) -> None:
+        now = datetime.now(UTC).isoformat()
+        self.record(
+            CommandResult(
+                name=name,
+                command="harness note",
+                cwd=str(self.workspace),
+                exit_code=0,
+                stdout=message,
+                stderr="",
+                started_at=now,
+                ended_at=now,
+            )
+        )
+
+    def connection_account(self) -> str:
+        result = self.run(
+            "read Snowflake CLI connection metadata",
+            ["snow", "connection", "list", "--format", "json"],
+            display_command="snow connection list --format json",
+        )
+        connections = json.loads(result.stdout)
+        for item in connections:
+            if item.get("connection_name") == self.connection:
+                account = item.get("parameters", {}).get("account")
+                if account:
+                    return account
+        raise SystemExit(f"Connection not found or missing account: {self.connection}")
+
+    def render_sql(self, public_key: str) -> Path:
+        rendered_dir = self.workspace / ".quickstart"
+        rendered_dir.mkdir(exist_ok=True)
+        rendered = rendered_dir / "setup_snowflake.rendered.sql"
+        source = self.workspace / "setup_snowflake.sql"
+        rendered.write_text(
+            source.read_text(encoding="utf-8").replace("<PUBLIC_KEY_VALUE>", public_key),
+            encoding="utf-8",
+        )
+        self.note(
+            "render setup_snowflake.sql",
+            "Rendered setup_snowflake.sql with the generated public key.",
+        )
+        return rendered
+
+    def write_env(self, *, account: str, password: str) -> None:
+        env_path = self.workspace / ".env"
+        key_path = self.workspace / "snowflake" / "rsa_key_encrypted.p8"
+        env_path.write_text(
+            "\n".join(
+                [
+                    f"SNOWFLAKE_ACCOUNT={account}",
+                    "SNOWFLAKE_USER=STREAMEV",
+                    f"SNOWFLAKE_PRIVATE_KEY_FILE={key_path}",
+                    f"SNOWFLAKE_PRIVATE_KEY_PASSWORD={password}",
+                    "SNOWFLAKE_WAREHOUSE=COMPUTE_WH",
+                    "SNOWFLAKE_DATABASE=INGESTION",
+                    "SNOWFLAKE_SCHEMA_NAME=PUBLIC",
+                    "SNOWFLAKE_ROLE=STREAM",
+                    "SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        self.note("create .env", "Created .env with generated key path and quickstart defaults.")
+
+    def write_summary(self) -> None:
+        first_failure = next((item for item in self.results if item.exit_code != 0), None)
+        summary: dict[str, Any] = {
+            "run_dir": str(self.run_dir),
+            "workspace": str(self.workspace),
+            "connection": self.connection,
+            "status": "failed" if self.failed else "passed",
+            "first_failure": None
+            if first_failure is None
+            else {
+                "name": first_failure.name,
+                "command": self.redact(first_failure.command),
+                "exit_code": first_failure.exit_code,
+            },
+            "commands_log": str(self.log_path),
+        }
+        self.summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    def execute_quickstart(self) -> None:
+        self.prepare()
+        password = secrets.token_urlsafe(24)
+        self.redactions[password] = "<KEY_PASSWORD>"
+
+        account = self.connection_account()
+        self.run(
+            "test setup connection",
+            ["snow", "connection", "test", "--connection", self.connection, "--format", "json"],
+            display_command=f"snow connection test --connection {self.connection} --format json",
+        )
+        self.run(
+            "generate RSA key",
+            ["./generate_snowflake_keys.sh"],
+            display_command="EVSNOW_KEY_PASSWORD=<KEY_PASSWORD> ./generate_snowflake_keys.sh",
+            env={"EVSNOW_KEY_PASSWORD": password},
+            timeout=120,
+        )
+        public_key_path = self.workspace / "snowflake" / "rsa_key_pub_value.txt"
+        public_key = public_key_path.read_text(encoding="utf-8").strip()
+        self.redactions[public_key] = "<PUBLIC_KEY_VALUE>"
+        self.record_existing_redactions()
+        self.note("read public key", "Read snowflake/rsa_key_pub_value.txt.")
+
+        rendered_setup = self.render_sql(public_key)
+        self.run(
+            "run setup_snowflake.sql",
+            [
+                "snow",
+                "sql",
+                "--connection",
+                self.connection,
+                "--format",
+                "json",
+                "--filename",
+                str(rendered_setup),
+            ],
+            display_command=(
+                "snow sql --connection "
+                f"{self.connection} --format json --filename .quickstart/setup_snowflake.rendered.sql"
+            ),
+        )
+        self.run(
+            "run setup_snowpipe_streaming.sql",
+            [
+                "snow",
+                "sql",
+                "--connection",
+                self.connection,
+                "--format",
+                "json",
+                "--filename",
+                "setup_snowpipe_streaming.sql",
+            ],
+            display_command=(
+                "snow sql --connection "
+                f"{self.connection} --format json --filename setup_snowpipe_streaming.sql"
+            ),
+        )
+        self.run(
+            "copy example config",
+            ["cp", "config/evsnow.example.toml", "config/evsnow.toml"],
+            display_command="cp config/evsnow.example.toml config/evsnow.toml",
+        )
+        self.write_env(account=account, password=password)
+        self.run(
+            "validate EvSnow config",
+            [
+                "uv",
+                "run",
+                "evsnow",
+                "validate-config",
+                "--config-file",
+                "config/evsnow.toml",
+                "--env-file",
+                ".env",
+            ],
+            stdin="n\n",
+            display_command=(
+                "printf 'n\\n' | uv run evsnow validate-config "
+                "--config-file config/evsnow.toml --env-file .env"
+            ),
+            timeout=240,
+        )
+        self.write_summary()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--connection", default=DEFAULT_CONNECTION)
+    parser.add_argument("--run-root", type=Path, default=DEFAULT_RUN_ROOT)
+    parser.add_argument(
+        "--keep-going",
+        action="store_true",
+        help="Continue after failures so the log captures later command behavior.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    harness = Harness(
+        connection=args.connection,
+        run_root=args.run_root,
+        keep_going=args.keep_going,
+    )
+    try:
+        harness.execute_quickstart()
+    finally:
+        harness.write_summary()
+        print(f"summary: {harness.summary_path}")
+        print(f"commands: {harness.log_path}")
+    return 1 if harness.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- make the Snowflake quickstart a single ordered bootstrap path with active-account prerequisites and object verification
- make setup_snowflake.sql self-contained for the runtime role/user/warehouse/databases/control table
- make key generation headless-friendly via `EVSNOW_KEY_PASSWORD` and avoid unencrypted private-key output by default
- add a quickstart harness that logs command stdout/stderr/exit codes with generated key material redacted
- switch Snowpipe setup to `IF NOT EXISTS` and update the static guard test

## Validation
- `uv run zensical build --clean --strict`
- `uv run pytest tests/unit/test_snowflake_internal_iceberg_setup.py tests/unit/test_config.py -q`
- `uv run pytest -q`
- `python3 tools/quickstart_harness.py --connection automa_zfelfof_nfa14829`

## Live Snowflake note
The harness reached Snowflake DDL and stopped because the trial account returns `000666 ... account is suspended due to lack of payment method`. The docs now call out that `snow connection test` can pass while setup DDL remains blocked by this account state.