### PR TITLE
[codex] Polish docs onboarding flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,196 +1,129 @@
-# ============================================================================
-# AZURE EVENT HUB CONFIGURATION
-# ============================================================================
-
-# Event Hub Namespace (replace with your actual namespace)
-# Format: <namespace-name>.servicebus.windows.net
-EVENTHUB_NAMESPACE=eventhub1.servicebus.windows.net
-
-# Topic configurations - map to payload directories
-# You can configure multiple topics by incrementing the number (EVENTHUBNAME_2, EVENTHUBNAME_3, etc.)
-EVENTHUBNAME_1=topic1
-EVENTHUBNAME_1_CONSUMER_GROUP=$Default
-
-# Starting position when no checkpoints exist (optional)
-# Options:
-#   -1       = Start from BEGINNING (process all existing messages) - DEFAULT
-#   @latest  = Start from LATEST (only process new messages after connection)
-# This only applies when starting fresh (no checkpoints). Normal operation resumes from saved checkpoints.
-EVENTHUBNAME_1_STARTING_POSITION_ON_NO_CHECKPOINT=-1
-
-# Entra ID authentication and Event Hubs SDK options (optional)
-# DefaultAzureCredential is the production-capable default; use azure_cli only for explicit local/dev testing.
-EVENTHUBNAME_1_CREDENTIAL_MODE=default
-# EVENTHUBNAME_1_MANAGED_IDENTITY_CLIENT_ID=user-assigned-managed-identity-client-id
-EVENTHUBNAME_1_PREFETCH_COUNT=300
-EVENTHUBNAME_1_MAX_WAIT_TIME=60
-EVENTHUBNAME_1_RETRY_TOTAL=3
-EVENTHUBNAME_1_RETRY_BACKOFF_FACTOR=0.8
-EVENTHUBNAME_1_RETRY_BACKOFF_MAX=120
-EVENTHUBNAME_1_RETRY_MODE=exponential
-EVENTHUBNAME_1_LOAD_BALANCING_INTERVAL=30
-# EVENTHUBNAME_1_PARTITION_OWNERSHIP_EXPIRATION_INTERVAL=180
-EVENTHUBNAME_1_LOAD_BALANCING_STRATEGY=greedy
-EVENTHUBNAME_1_TRACK_LAST_ENQUEUED_EVENT_PROPERTIES=false
-
-# Azure EventHub Connection String (explicit alternative to Entra ID auth)
-# Get this from Azure Portal → Event Hubs Namespace → Shared access policies
-# The pipeline uses DefaultAzureCredential unless EVENTHUBNAME_{N}_CONNECTION_STRING is set.
-# EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://eventhub1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somekey"
+# EvSnow local environment template
+#
+# Copy this file to `.env` for local runs:
+#
+#   cp .env.example .env
+#
+# Keep pipeline shape in `config/evsnow.toml`: Event Hub names, target tables,
+# mappings, control-table backend, and ownership mode belong there for the
+# standard first-run path. Values in an explicit `--env-file` override TOML, so
+# this template keeps those shape keys commented unless you intentionally choose
+# an env-only configuration.
 
 # ============================================================================
 # SNOWFLAKE CONNECTION SETTINGS
 # ============================================================================
 
-# Account identifier format: <account_locator>.<region> (e.g., xy12345.us-east-1)
-# Find your account identifier: SELECT CURRENT_ACCOUNT() in Snowflake
+# Account identifier format: <org>-<account>, <account_locator>.<region>, or
+# another Snowflake-supported account identifier.
 SNOWFLAKE_ACCOUNT=aaaaaa-bbbbbbb
 
-# Snowflake user with appropriate permissions
+# Runtime service user created by setup_snowflake.sql.
 SNOWFLAKE_USER=STREAMEV
 
-# RSA Key-Pair Authentication (recommended)
-# Generate keys using: ./generate_snowflake_keys.sh
-# See SNOWFLAKE_QUICKSTART.md for setup instructions
-SNOWFLAKE_PRIVATE_KEY_FILE=/path/to/your/snowflake/rsa_key_encrypted.p8
+# RSA key-pair authentication.
+# Generate keys with: ./generate_snowflake_keys.sh
+# See docs/getting-started/snowflake-quickstart.md for setup instructions.
+SNOWFLAKE_PRIVATE_KEY_FILE=snowflake/rsa_key_encrypted.p8
 SNOWFLAKE_PRIVATE_KEY_PASSWORD=your_key_password_here
 
-# Snowflake resources
-SNOWFLAKE_WAREHOUSE=compute_wh
-SNOWFLAKE_ROLE=STREAM  # Optional - role to use for operations
-# For one mapped target, EvSnow derives connection session database/schema
-# from SNOWFLAKE_1_DATABASE and SNOWFLAKE_1_SCHEMA below. If you map to
-# multiple database/schema pairs, set these explicitly:
+# Runtime warehouse, role, session context, and Snowpipe Streaming pipe.
+SNOWFLAKE_WAREHOUSE=COMPUTE_WH
+SNOWFLAKE_ROLE=STREAM
+SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
+
+# For one mapped Snowflake target, EvSnow derives the session database/schema
+# from config/evsnow.toml. Uncomment these only when you need to set an explicit
+# session context, such as when mappings span multiple database/schema pairs.
 # SNOWFLAKE_DATABASE=INGESTION
 # SNOWFLAKE_SCHEMA_NAME=PUBLIC
 
 # ============================================================================
-# CONTROL TABLE CONFIGURATION
+# EVENT HUB AUTHENTICATION SECRETS
 # ============================================================================
 
-# Control table for checkpointing and watermark management
-# The INGESTION_STATUS table will be created here automatically
-TARGET_DB=CONTROL
-TARGET_SCHEMA=PUBLIC
-TARGET_TABLE=INGESTION_STATUS
+# The first-run TOML uses Azure CLI auth:
+#
+#   [eventhub_defaults]
+#   credential_mode = "azure_cli"
+#
+# Leave connection strings unset for that path. Uncomment one of these only
+# when you intentionally use connection-string authentication.
 
-# Control table backend (default: snowflake)
-# Options: snowflake, postgres
-CONTROL_TABLE_BACKEND=snowflake
-
-# Use Hybrid Table for the control table (default: false)
-# Set to true if you have a paid Snowflake account for better OLTP performance
-# Hybrid tables are not available on trial accounts
-USE_HYBRID_TABLE=false
-
-# Partition ownership mode (default: durable)
-# durable: persist Event Hubs partition ownership in the configured control backend.
-# local_single_consumer_smoke: keep ownership in memory and persist only Snowflake
-# checkpoints. Use only for one local consumer when Hybrid Tables are unavailable.
-CONTROL_OWNERSHIP_MODE=durable
-
-# Postgres control table (only used when CONTROL_TABLE_BACKEND=postgres)
-CONTROL_PG_HOST=localhost
-CONTROL_PG_PORT=5432
-CONTROL_PG_USER=checkpoint_user
-CONTROL_PG_PASSWORD=checkpoint_password
-CONTROL_PG_SSLMODE=require
-CONTROL_PG_AUTH_MODE=password  # password | azure_token
-# Notes:
-# - TARGET_DB/TARGET_SCHEMA/TARGET_TABLE are normalized to lowercase for Postgres unless quoted.
-# - azure_token auth uses DefaultAzureCredential; CONTROL_PG_PASSWORD is ignored.
+# EVENTHUBNAME_1_CONNECTION_STRING="Endpoint=sb://eventhub1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somekey"
+# AZURE_EVENTHUB_CONNECTION_STRING="Endpoint=sb://eventhub1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=somekey"
 
 # ============================================================================
-# SNOWFLAKE INGESTION MAPPING
+# POSTGRES CONTROL BACKEND SECRETS
 # ============================================================================
 
-# Snowflake ingestion configuration for EventHub topic1
-# Maps EVENTHUBNAME_1 → SNOWFLAKE_1
-SNOWFLAKE_1_DATABASE=INGESTION
-SNOWFLAKE_1_SCHEMA=PUBLIC
-SNOWFLAKE_1_TABLE=EVENTS_TABLE1
-SNOWFLAKE_1_BATCH=100
-SNOWFLAKE_1_CLIENT_REFRESH_INTERVAL_SECONDS=0
+# Use these only when config/evsnow.toml selects:
+#
+#   [control]
+#   backend = "postgres"
 
-# Add more mappings as needed:
-# EVENTHUBNAME_2=topic2
-# EVENTHUBNAME_2_CONSUMER_GROUP=$Default
-# SNOWFLAKE_2_DATABASE=INGESTION
-# SNOWFLAKE_2_SCHEMA=PUBLIC
-# SNOWFLAKE_2_TABLE=other_events_table
-# SNOWFLAKE_2_BATCH=100
+# CONTROL_PG_PASSWORD=checkpoint_password
+
+# For Azure token auth, set this in TOML and leave the password unset:
+#
+#   [control.postgres]
+#   auth_mode = "azure_token"
 
 # ============================================================================
-# SNOWFLAKE SNOWPIPE STREAMING CONFIGURATION
+# SMART RETRY CONFIGURATION
 # ============================================================================
 
-# PIPE object name (must exist in Snowflake)
-# Create using setup_snowpipe_streaming.sql
-# The PIPE name typically matches your table name with _PIPE suffix
-SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
+# Smart retry is enabled per run with `uv run evsnow run --smart`.
+SMART_RETRY_ENABLED=false
 
-# ============================================================================
-# SMART RETRY CONFIGURATION (OPTIONAL)
-# ============================================================================
-
-# Enable LLM-powered intelligent retry decisions
-# Analyzes exceptions to determine if operations should be retried
-# Use with: uv run python src/main.py run --smart
-SMART_RETRY_ENABLED=true
-
-# LLM Provider Configuration
-# Supported: openai, azure, anthropic, gemini, groq, cohere
-SMART_RETRY_LLM_PROVIDER=azure
-SMART_RETRY_LLM_MODEL=gpt-4o-mini  # For Azure: your deployment name
-
-# API Authentication
-SMART_RETRY_LLM_API_KEY=KEY
-
-# Azure OpenAI Endpoint (required when provider=azure)
-# Format: https://<resource>.cognitiveservices.azure.com/openai/responses?api-version=2025-04-01-preview
-SMART_RETRY_LLM_ENDPOINT=https://yourdeployment.cognitiveservices.azure.com/openai/responses?api-version=2025-04-01-preview
-
-# Retry Behavior
-SMART_RETRY_MAX_ATTEMPTS=3           # Maximum retry attempts (1-10)
-SMART_RETRY_TIMEOUT_SECONDS=10       # LLM request timeout (1-60 seconds)
-SMART_RETRY_ENABLE_CACHING=true      # Cache LLM decisions for similar errors
-
-# Example OpenAI Configuration:
+# Uncomment and fill these only when using `--smart`.
 # SMART_RETRY_LLM_PROVIDER=openai
 # SMART_RETRY_LLM_MODEL=gpt-4o-mini
 # SMART_RETRY_LLM_API_KEY=sk-your-api-key-here
-# SMART_RETRY_LLM_ENDPOINT=  # Leave empty for OpenAI
+# SMART_RETRY_LLM_ENDPOINT=
+# SMART_RETRY_MAX_ATTEMPTS=3
+# SMART_RETRY_TIMEOUT_SECONDS=10
+# SMART_RETRY_ENABLE_CACHING=true
 
 # ============================================================================
-# LOGFIRE OBSERVABILITY (OPTIONAL)
+# LOGFIRE OBSERVABILITY
 # ============================================================================
 
-# Enable real-time distributed tracing and observability
-# Sign up for free at: https://logfire.pydantic.dev
-LOGFIRE_ENABLED=true
+LOGFIRE_ENABLED=false
 
-# Logfire API Token (required when send_to_logfire=true)
-# Get your token from Logfire dashboard
-LOGFIRE_TOKEN=your_key_logfire
-
-# Service Configuration
-LOGFIRE_SERVICE_NAME=your_service_name
-LOGFIRE_ENVIRONMENT=development
-
-# Output Configuration
-# Send traces to Logfire cloud (requires token)
-LOGFIRE_SEND_TO_LOGFIRE=true
-# Enable Rich console output with traces
-LOGFIRE_CONSOLE_LOGGING=true
-
-# Log Level: DEBUG, INFO, WARNING, ERROR, CRITICAL
-LOGFIRE_LOG_LEVEL=INFO
-
-# Example Production Configuration:
-# LOGFIRE_ENABLED=true
-# LOGFIRE_TOKEN=pylf_v1_us_your-production-token
-# LOGFIRE_SERVICE_NAME=evsnow-prod
-# LOGFIRE_ENVIRONMENT=production
+# Uncomment and fill these when sending traces to Logfire.
+# LOGFIRE_TOKEN=pylf_v1_us_your-token
+# LOGFIRE_SERVICE_NAME=evsnow-local
+# LOGFIRE_ENVIRONMENT=development
 # LOGFIRE_SEND_TO_LOGFIRE=true
-# LOGFIRE_CONSOLE_LOGGING=false
-# LOGFIRE_LOG_LEVEL=WARNING
+# LOGFIRE_CONSOLE_LOGGING=true
+# LOGFIRE_LOG_LEVEL=INFO
+
+# ============================================================================
+# ENV-ONLY PIPELINE SHAPE (ADVANCED)
+# ============================================================================
+
+# Prefer config/evsnow.toml for these values. Uncomment this block only when
+# you are intentionally running without `config/evsnow.toml`.
+
+# EVENTHUB_NAMESPACE=eventhub1.servicebus.windows.net
+# ENVIRONMENT=development
+# REGION=local
+#
+# TARGET_DB=CONTROL
+# TARGET_SCHEMA=PUBLIC
+# TARGET_TABLE=INGESTION_STATUS
+# CONTROL_TABLE_BACKEND=snowflake
+# USE_HYBRID_TABLE=false
+# CONTROL_OWNERSHIP_MODE=local_single_consumer_smoke
+#
+# EVENTHUBNAME_1=topic1
+# EVENTHUBNAME_1_CONSUMER_GROUP=$Default
+# EVENTHUBNAME_1_CREDENTIAL_MODE=azure_cli
+# EVENTHUBNAME_1_STARTING_POSITION_ON_NO_CHECKPOINT=-1
+#
+# SNOWFLAKE_1_DATABASE=INGESTION
+# SNOWFLAKE_1_SCHEMA=PUBLIC
+# SNOWFLAKE_1_TABLE=EVENTS_TABLE1
+# SNOWFLAKE_1_BATCH=100
+# SNOWFLAKE_1_CLIENT_REFRESH_INTERVAL_SECONDS=0

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# evsnow
+# EvSnow
 
 EvSnow streams events from Azure Event Hubs into Snowflake with checkpointing,
 configuration validation, and observability.
-
-The full documentation is built with Zensical and published through GitHub
-Pages:
-
-- Documentation site: <https://miguelelgallo.github.io/evsnow/>
-- First local run: [docs/tutorial/first-run.md](docs/tutorial/first-run.md)
-- Configuration reference: [docs/configuration.md](docs/configuration.md)
-- Snowflake setup: [docs/getting-started/snowflake-quickstart.md](docs/getting-started/snowflake-quickstart.md)
 
 [![Tests](https://github.com/MiguelElGallo/evsnow/actions/workflows/tests.yml/badge.svg)](https://github.com/MiguelElGallo/evsnow/actions/workflows/tests.yml)
 [![CI/CD Pipeline](https://github.com/MiguelElGallo/evsnow/actions/workflows/ci-cd.yml/badge.svg)](https://github.com/MiguelElGallo/evsnow/actions/workflows/ci-cd.yml)
 [![Documentation](https://github.com/MiguelElGallo/evsnow/actions/workflows/docs.yml/badge.svg)](https://github.com/MiguelElGallo/evsnow/actions/workflows/docs.yml)
 [![codecov](https://codecov.io/gh/MiguelElGallo/evsnow/branch/main/graph/badge.svg)](https://codecov.io/gh/MiguelElGallo/evsnow)
 
+Read the hosted docs at <https://miguelelgallo.github.io/evsnow/>.
+
 ## Quick Start
+
+Use TOML for pipeline shape and `.env` for secrets or local credentials:
+
+Fresh Snowflake accounts should start with
+[Snowflake quickstart](docs/getting-started/snowflake-quickstart.md). If the
+Snowflake objects already exist, run:
 
 ```bash
 git clone https://github.com/MiguelElGallo/evsnow.git
@@ -24,12 +24,16 @@ cd evsnow
 uv sync
 cp config/evsnow.example.toml config/evsnow.toml
 cp .env.example .env
-# Edit config/evsnow.toml and .env, then validate.
+
+# Edit config/evsnow.toml for Event Hub, Snowflake target, and mappings.
+# Edit .env for Snowflake credentials and local secrets.
 uv run evsnow validate-config --config-file config/evsnow.toml --env-file .env
 ```
 
-Edit `.env` before validation. Keep pipeline shape in
-`config/evsnow.toml`; use `.env` for secrets and local credentials.
+Then continue with [First run](docs/tutorial/first-run.md).
+
+The full configuration surface is documented in
+[Parameter reference](docs/reference/parameters.md).
 
 ## Documentation Development
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,15 +79,24 @@ Run validation before starting the pipeline:
 uv run evsnow validate-config --config-file config/evsnow.toml --env-file .env
 ```
 
-EvSnow loads the TOML file, then applies values from `.env`, then applies real environment variables.
+EvSnow loads `config/evsnow.toml` for shape and then applies environment
+values. There are two environment-file paths:
+
+- A default `.env` file is loaded automatically if present, but it does not
+  replace variables already set in the shell.
+- An explicit `--env-file` is loaded with override semantics, so that file can
+  replace shell values and TOML-derived values for the command.
 
 So the order is:
 
 ```text
-model defaults < TOML < .env / --env-file < process environment < CLI runtime flags
+model defaults < TOML < default .env < process environment < explicit --env-file < CLI runtime flags
 ```
 
-This lets TOML describe the default pipeline, while local shells and deployment systems can still override values.
+This lets TOML describe the default pipeline, while local shells, deployment
+systems, and explicit command env files can still override values. For the first
+run, keep pipeline shape out of `.env` so the TOML remains the source you
+inspect.
 
 ## Run with TOML
 

--- a/docs/getting-started/snowflake-quickstart.md
+++ b/docs/getting-started/snowflake-quickstart.md
@@ -130,6 +130,16 @@ The pipe check must return `EVENTS_TABLE_PIPE`, and the grant checks must show
 the runtime role has table access plus `OPERATE` and `MONITOR` on the pipe.
 `DESC USER STREAMEV` should show `TYPE = SERVICE`.
 
+Keep this checklist as the known-good proof before moving on:
+
+| Check | Expected result |
+|-------|-----------------|
+| `DESC USER STREAMEV` | `TYPE` is `SERVICE` |
+| `SHOW GRANTS TO ROLE STREAM` | `CREATE SCHEMA` on `CONTROL`, `CREATE TABLE` on `CONTROL.PUBLIC`, and DML on `CONTROL.PUBLIC.INGESTION_STATUS` |
+| `SHOW PIPES LIKE 'EVENTS_TABLE_PIPE'` | One pipe named `EVENTS_TABLE_PIPE` in `INGESTION.PUBLIC` |
+| `SHOW GRANTS ON PIPE INGESTION.PUBLIC.EVENTS_TABLE_PIPE` | `STREAM` has `OPERATE` and `MONITOR` |
+| `DESC TABLE INGESTION.PUBLIC.EVENTS_TABLE1` | The target table exists before EvSnow starts |
+
 ## Configure EvSnow
 
 ```bash
@@ -154,11 +164,14 @@ SNOWFLAKE_USER=STREAMEV
 SNOWFLAKE_PRIVATE_KEY_FILE=snowflake/rsa_key_encrypted.p8
 SNOWFLAKE_PRIVATE_KEY_PASSWORD=<key-password>
 SNOWFLAKE_WAREHOUSE=COMPUTE_WH
-SNOWFLAKE_DATABASE=INGESTION
-SNOWFLAKE_SCHEMA_NAME=PUBLIC
 SNOWFLAKE_ROLE=STREAM
 SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
 ```
+
+For this one-target quickstart, EvSnow derives the Snowflake session
+database/schema from `config/evsnow.toml`. Set `SNOWFLAKE_DATABASE` and
+`SNOWFLAKE_SCHEMA_NAME` only when you map to multiple database/schema pairs or
+need an explicit session context.
 
 The full environment template remains in
 [`.env.example`](https://github.com/MiguelElGallo/evsnow/blob/main/.env.example).
@@ -176,6 +189,8 @@ pipe grants exist.
 Treat any warning as a setup failure even if the command exits `0`. In
 particular, `Warning: Could not verify Snowflake control table` means the
 runtime role still lacks the control-table privileges needed by validation.
+The expected success marker is
+`Snowflake control table verified/created successfully` with no warnings.
 
 After validation passes without warnings, continue with
 [First run](../tutorial/first-run.md).

--- a/docs/project/workflows.md
+++ b/docs/project/workflows.md
@@ -41,6 +41,29 @@ Manual run:
 gh workflow run ci-cd.yml
 ```
 
+### Documentation (`.github/workflows/docs.yml`)
+
+Builds the Zensical documentation site on pull requests and deploys it to
+GitHub Pages after changes land on `main`.
+
+- Dependency install: `uv sync --group docs --locked`
+- Build command: `uv run zensical build --clean --strict`
+- Artifact path: `site`
+- Deploy target: GitHub Pages environment
+- Live site: `https://miguelelgallo.github.io/evsnow/`
+
+The deploy job only runs on pushes to `main`. Pull requests build the site but
+do not publish it.
+
+Manual run:
+
+```bash
+gh workflow run docs.yml
+```
+
+Manual runs build the docs only. Deployment happens after a push or merge to
+`main`, because the deploy job is gated to push events.
+
 ### Copilot Setup (`.github/workflows/copilot-setup-steps.yml`)
 
 Prepares the repository for GitHub Copilot coding-agent sessions.
@@ -62,11 +85,37 @@ uv run ty check src/
 uv run pytest
 ```
 
+For docs-only changes:
+
+```bash
+uv sync --group docs --locked
+uv run zensical build --clean --strict
+```
+
+After a docs PR is merged, verify the main-branch Documentation run and check
+the live Pages content with a cache-busting query string:
+
+```bash
+gh run list --workflow docs.yml --branch main --limit 3
+curl -fsSL "https://miguelelgallo.github.io/evsnow/?v=<commit-sha>" >/dev/null
+curl -fsSL "https://miguelelgallo.github.io/evsnow/getting-started/snowflake-quickstart/?v=<commit-sha>" \
+  | rg "Snowflake control table verified/created successfully"
+curl -fsSL "https://miguelelgallo.github.io/evsnow/tutorial/first-run/?v=<commit-sha>" \
+  | rg "Choose Your Starting Point"
+curl -fsSL "https://miguelelgallo.github.io/evsnow/reference/parameters/?v=<commit-sha>" \
+  | rg "explicit --env-file"
+```
+
+For other content-sensitive docs changes, search for one or two exact markers
+from the changed page in the live HTML before calling the publication complete.
+
 ## Troubleshooting
 
 - If CI fails on dependency resolution, run `uv lock --check --python 3.13`.
 - If local tests differ from CI, confirm you are using Python 3.13 and the checked-in `uv.lock`.
 - If Codecov does not report, verify `CODECOV_TOKEN` and the coverage artifact steps.
+- If the live docs still show old content after a successful deployment, retry
+  with a cache-busting query string and verify the GitHub Pages deploy job.
 
 ## See Also
 

--- a/docs/reference/parameters.md
+++ b/docs/reference/parameters.md
@@ -9,12 +9,14 @@ credentials, tokens, passwords, and machine-specific paths.
 EvSnow loads values in this order:
 
 ```text
-model defaults < TOML < process environment < explicit --env-file < CLI runtime flags
+model defaults < TOML < default .env < process environment < explicit --env-file < CLI runtime flags
 ```
 
-The default `.env` file is loaded when the CLI starts. An explicit `--env-file`
-is loaded with override semantics, so it can replace values already present in
-the shell environment.
+The default `.env` file is loaded when the CLI starts, but it does not replace
+variables already present in the shell. An explicit `--env-file` is loaded with
+override semantics, so it can replace shell values and TOML-derived values for
+that command. Prefer keeping pipeline shape in TOML and using `.env` for
+secrets, local paths, and connection credentials.
 
 Find the right section:
 

--- a/docs/tools/eventhub-sender.md
+++ b/docs/tools/eventhub-sender.md
@@ -20,8 +20,9 @@ Or use a connection string (env var supported):
 export AZURE_EVENTHUB_CONNECTION_STRING="Endpoint=sb://...;SharedAccessKey=..."
 uv run python tools/eventhub_sender/main.py --eventhub my-hub --count 20
 
-# If your .env already has EVENTHUB_NAMESPACE, EVENTHUBNAME_1, and AZURE_EVENTHUB_CONNECTION_STRING,
-# you can omit those flags and the CLI will pick them up automatically:
+# If you intentionally use an env-only configuration with EVENTHUB_NAMESPACE,
+# EVENTHUBNAME_1, and AZURE_EVENTHUB_CONNECTION_STRING, you can omit those
+# flags and the CLI will pick them up automatically:
 uv run python tools/eventhub_sender/main.py --count 20
 ```
 
@@ -52,8 +53,12 @@ Snowflake.
 ```bash
 RUN_ID="evsnow-smoke-$(date -u +%Y%m%dT%H%M%SZ)"
 START_ID=$(date -u +%s)
+EVENTHUB_NAMESPACE="eventhub1.servicebus.windows.net"
+EVENTHUB_NAME="topic1"
 
 uv run python tools/eventhub_sender/main.py \
+  --namespace "$EVENTHUB_NAMESPACE" \
+  --eventhub "$EVENTHUB_NAME" \
   --count 3 \
   --start-id "$START_ID" \
   --batch-size 3 \
@@ -68,6 +73,10 @@ set -a
 source .env
 set +a
 
+TARGET_DATABASE=INGESTION
+TARGET_SCHEMA=PUBLIC
+TARGET_TABLE=EVENTS_TABLE1
+
 snow sql -x \
   --account "$SNOWFLAKE_ACCOUNT" \
   --user "$SNOWFLAKE_USER" \
@@ -75,16 +84,21 @@ snow sql -x \
   --private-key-file "$SNOWFLAKE_PRIVATE_KEY_FILE" \
   --role "$SNOWFLAKE_ROLE" \
   --warehouse "$SNOWFLAKE_WAREHOUSE" \
-  --database "$SNOWFLAKE_1_DATABASE" \
-  --schema "$SNOWFLAKE_1_SCHEMA" \
+  --database "$TARGET_DATABASE" \
+  --schema "$TARGET_SCHEMA" \
   --format JSON \
   -q "SELECT COUNT(*) AS rows_arrived,
              LISTAGG(TRY_PARSE_JSON(EVENT_BODY):sequence_id::STRING, ',')
                WITHIN GROUP (ORDER BY TRY_PARSE_JSON(EVENT_BODY):sequence_id::NUMBER)
              AS sequence_ids
-      FROM ${SNOWFLAKE_1_DATABASE}.${SNOWFLAKE_1_SCHEMA}.${SNOWFLAKE_1_TABLE}
+      FROM ${TARGET_DATABASE}.${TARGET_SCHEMA}.${TARGET_TABLE}
       WHERE TRY_PARSE_JSON(EVENT_BODY):payload:run_id::STRING = '$RUN_ID';"
 ```
 
 For a 3-message smoke test, `rows_arrived` should be `3` and the
 `sequence_ids` should be consecutive.
+
+Use the Event Hub and target values from `config/evsnow.toml`. If you
+intentionally run with env-only shape, you can set `EVENTHUB_NAMESPACE`,
+`EVENTHUB_NAME`, `TARGET_DATABASE`, `TARGET_SCHEMA`, and `TARGET_TABLE` from
+the matching env variables instead.

--- a/docs/tutorial/first-run.md
+++ b/docs/tutorial/first-run.md
@@ -8,6 +8,14 @@ Fresh Snowflake accounts should complete
 tutorial assumes the `STREAM` role, `STREAMEV` user, `CONTROL` database,
 `INGESTION` database, target Iceberg table, and streaming pipe already exist.
 
+## Choose Your Starting Point
+
+- If the Snowflake objects do not exist yet, run
+  [Snowflake quickstart](../getting-started/snowflake-quickstart.md), then come
+  back here.
+- If the objects already exist, continue below and create only the runtime
+  files.
+
 ## Install
 
 ```bash
@@ -64,7 +72,14 @@ first smoke test. `EVENTHUBNAME_1` and `SNOWFLAKE_1` are local mapping keys.
 
 ## Create `.env`
 
-Use the encrypted key created during Snowflake setup, then create `.env`:
+Use the encrypted key created during Snowflake setup. You can start from the
+local template:
+
+```bash
+cp .env.example .env
+```
+
+Then keep only the local credentials needed by the run:
 
 ```bash
 SNOWFLAKE_ACCOUNT=aaaaaa-bbbbbbb
@@ -72,15 +87,15 @@ SNOWFLAKE_USER=STREAMEV
 SNOWFLAKE_PRIVATE_KEY_FILE=snowflake/rsa_key_encrypted.p8
 SNOWFLAKE_PRIVATE_KEY_PASSWORD=your-password
 SNOWFLAKE_WAREHOUSE=COMPUTE_WH
-SNOWFLAKE_DATABASE=INGESTION
-SNOWFLAKE_SCHEMA_NAME=PUBLIC
 SNOWFLAKE_ROLE=STREAM
 SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE
 ```
 
 Do not put pipeline shape keys such as `EVENTHUB_NAMESPACE`, `TARGET_DB`, or
-`SNOWFLAKE_1_DATABASE` in `.env` for this path. Environment variables override
-TOML, so keeping shape in TOML makes the run easier to inspect.
+`SNOWFLAKE_1_DATABASE` in `.env` for this path. An explicit `--env-file`
+overrides TOML, so keeping shape in TOML makes the run easier to inspect.
+For one mapped Snowflake target, EvSnow derives the Snowflake session
+database/schema from the target in `config/evsnow.toml`.
 
 ## Validate
 
@@ -117,11 +132,13 @@ Open terminal 2 and send test messages:
 uv run python tools/eventhub_sender/main.py \
   --namespace eventhub1.servicebus.windows.net \
   --eventhub topic1 \
-  --count 10000 \
-  --batch-size 1000
+  --count 3 \
+  --batch-size 3
 ```
 
 Use the namespace and Event Hub name from `config/evsnow.toml`.
+Use [Event Hub sender](../tools/eventhub-sender.md) when you want a repeatable
+arrival check against Snowflake after the first pipeline starts cleanly.
 
 ## What Happened
 

--- a/tests/unit/test_snowflake_internal_iceberg_setup.py
+++ b/tests/unit/test_snowflake_internal_iceberg_setup.py
@@ -12,6 +12,9 @@ QUICKSTART = REPO_ROOT / "docs" / "getting-started" / "snowflake-quickstart.md"
 COMPLETE_SETUP = REPO_ROOT / "docs" / "snowflake" / "complete-setup.md"
 PARAMETERS = REPO_ROOT / "docs" / "reference" / "parameters.md"
 QUICKSTART_HARNESS = REPO_ROOT / "tools" / "quickstart_harness.py"
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+CONFIGURATION = REPO_ROOT / "docs" / "configuration.md"
+ZENSICAL = REPO_ROOT / "zensical.toml"
 
 
 def _normalized(path: Path) -> str:
@@ -116,6 +119,44 @@ def test_parameter_reference_covers_config_surfaces():
 
     for term in required_terms:
         assert term in docs
+
+
+def test_env_example_keeps_first_run_shape_in_toml():
+    active_keys = {
+        line.split("=", 1)[0]
+        for line in ENV_EXAMPLE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#") and "=" in line
+    }
+
+    shape_keys = {
+        "EVENTHUB_NAMESPACE",
+        "EVENTHUBNAME_1",
+        "TARGET_DB",
+        "TARGET_SCHEMA",
+        "TARGET_TABLE",
+        "CONTROL_TABLE_BACKEND",
+        "CONTROL_OWNERSHIP_MODE",
+        "SNOWFLAKE_1_DATABASE",
+        "SNOWFLAKE_1_SCHEMA",
+        "SNOWFLAKE_1_TABLE",
+    }
+
+    assert active_keys.isdisjoint(shape_keys)
+
+
+def test_docs_explain_default_and_explicit_env_precedence():
+    docs = "\n".join(_normalized(path) for path in (CONFIGURATION, PARAMETERS))
+
+    assert "DEFAULT .ENV" in docs
+    assert "DOES NOT REPLACE VARIABLES ALREADY" in docs
+    assert "EXPLICIT --ENV-FILE" in docs
+    assert "OVERRIDE SEMANTICS" in docs
+
+
+def test_zensical_enables_code_copy_buttons():
+    config = ZENSICAL.read_text(encoding="utf-8")
+
+    assert '"content.code.copy"' in config
 
 
 def test_quickstart_harness_fails_on_validation_warnings():

--- a/zensical.toml
+++ b/zensical.toml
@@ -59,6 +59,7 @@ variant = "modern"
 features = [
   "content.action.edit",
   "content.action.view",
+  "content.code.copy",
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.tabs",


### PR DESCRIPTION
## Summary
- make the first-run docs TOML-first by keeping pipeline shape out of active .env.example values
- clarify default .env versus explicit --env-file precedence across configuration docs
- tighten first-run, sender arrival-check, Snowflake quickstart proof, and docs publication runbook
- enable Zensical code copy buttons globally with content.code.copy

## Validation
- git diff --check
- uv run zensical build --clean --strict
- uv run pytest tests/unit/test_snowflake_internal_iceberg_setup.py tests/unit/test_config.py -q (107 passed)
- uv run pytest -q (457 passed, 1 warning)

## Peer review
- Zensical specialist: GO
- Documentation specialist: GO
- PM/auditor: GO