### PR TITLE
Improve docs end-to-end onboarding

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,12 @@ jobs:
       - name: Build documentation
         run: uv run zensical build --clean --strict
 
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
   deploy:
     name: Deploy to GitHub Pages
     if: github.event_name == 'push'
@@ -72,30 +78,6 @@ jobs:
     steps:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
-
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install UV
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-
-      - name: Install docs dependencies
-        run: uv sync --group docs --locked
-
-      - name: Build documentation
-        run: uv run zensical build --clean --strict
-
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: site
 
       - name: Deploy GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Read the hosted docs at <https://miguelelgallo.github.io/evsnow/>.
 
 Use TOML for pipeline shape and `.env` for secrets or local credentials:
 
-Fresh Snowflake accounts should start with
-[Snowflake quickstart](docs/getting-started/snowflake-quickstart.md). If the
-Snowflake objects already exist, run:
+Fresh Event Hub namespaces should start with
+[Event Hub quickstart](docs/getting-started/event-hub-quickstart.md). Fresh
+Snowflake accounts should start with
+[Snowflake quickstart](docs/getting-started/snowflake-quickstart.md). If both
+already exist, run:
 
 ```bash
 git clone https://github.com/MiguelElGallo/evsnow.git
@@ -38,7 +40,7 @@ The full configuration surface is documented in
 ## Documentation Development
 
 ```bash
-uv sync --group docs
+uv sync --group docs --locked
 uv run zensical build --clean --strict
 uv run zensical serve
 ```

--- a/docs/getting-started/event-hub-quickstart.md
+++ b/docs/getting-started/event-hub-quickstart.md
@@ -1,0 +1,130 @@
+# Event Hub Quickstart
+
+Use this page when you do not already have an Azure Event Hubs namespace and
+Event Hub for the first run.
+
+## Before You Start
+
+You need Azure CLI access to a subscription where you can create resource
+groups, Event Hubs namespaces, Event Hubs, and role assignments.
+
+```bash
+az login
+az account set --subscription <subscription-id-or-name>
+```
+
+## Create The Event Hub
+
+Pick a globally unique namespace name. EvSnow expects the fully qualified
+namespace value to end with `.servicebus.windows.net`.
+
+```bash
+LOCATION=eastus
+RESOURCE_GROUP=evsnow-quickstart-rg
+EVENTHUB_NAMESPACE=<globally-unique-namespace>
+EVENTHUB_NAME=topic1
+
+az group create \
+  --name "$RESOURCE_GROUP" \
+  --location "$LOCATION"
+
+az eventhubs namespace create \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$EVENTHUB_NAMESPACE" \
+  --location "$LOCATION" \
+  --sku Standard
+
+az eventhubs eventhub create \
+  --resource-group "$RESOURCE_GROUP" \
+  --namespace-name "$EVENTHUB_NAMESPACE" \
+  --name "$EVENTHUB_NAME" \
+  --partition-count 2 \
+  --retention-time 24
+```
+
+Use these values in `config/evsnow.toml`:
+
+```toml
+eventhub_namespace = "<globally-unique-namespace>.servicebus.windows.net"
+
+[event_hubs.EVENTHUBNAME_1]
+name = "topic1"
+namespace = "<globally-unique-namespace>.servicebus.windows.net"
+consumer_group = "$Default"
+```
+
+## Grant Local Smoke-Test Access
+
+The EvSnow consumer needs receive access. The included sender utility also
+needs send access when the same signed-in Azure CLI identity publishes test
+messages.
+
+```bash
+ASSIGNEE_OBJECT_ID="$(az ad signed-in-user show --query id -o tsv)"
+NAMESPACE_SCOPE="$(az eventhubs namespace show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$EVENTHUB_NAMESPACE" \
+  --query id -o tsv)"
+
+az role assignment create \
+  --assignee-object-id "$ASSIGNEE_OBJECT_ID" \
+  --assignee-principal-type User \
+  --role "Azure Event Hubs Data Receiver" \
+  --scope "$NAMESPACE_SCOPE"
+
+az role assignment create \
+  --assignee-object-id "$ASSIGNEE_OBJECT_ID" \
+  --assignee-principal-type User \
+  --role "Azure Event Hubs Data Sender" \
+  --scope "$NAMESPACE_SCOPE"
+```
+
+Role assignments can take a few minutes to propagate. If the first receiver or
+sender attempt fails with an authorization error, wait and retry before changing
+the EvSnow configuration.
+
+## Verify The Resources
+
+```bash
+az eventhubs namespace show \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$EVENTHUB_NAMESPACE" \
+  --query "{name:name,serviceBusEndpoint:serviceBusEndpoint}" \
+  -o table
+
+az eventhubs eventhub show \
+  --resource-group "$RESOURCE_GROUP" \
+  --namespace-name "$EVENTHUB_NAMESPACE" \
+  --name "$EVENTHUB_NAME" \
+  --query "{name:name,partitionCount:partitionCount,status:status}" \
+  -o table
+```
+
+The namespace endpoint should contain
+`<globally-unique-namespace>.servicebus.windows.net`, and the Event Hub status
+should be `Active`.
+
+## Verify Sender RBAC
+
+Send one message with the same Azure CLI identity you will use for the local
+first run:
+
+```bash
+uv sync
+
+uv run python tools/eventhub_sender/main.py \
+  --namespace "${EVENTHUB_NAMESPACE}.servicebus.windows.net" \
+  --eventhub "$EVENTHUB_NAME" \
+  --count 1 \
+  --batch-size 1 \
+  --payload '{"purpose":"eventhub-rbac-smoke"}'
+```
+
+If this fails with an authorization error, wait a few minutes for role
+propagation and retry. Continue only after the sender smoke succeeds. The
+receiver role is proven in [First run](../tutorial/first-run.md), when EvSnow
+connects and starts reading from the Event Hub.
+
+After the Event Hub exists, continue with [Snowflake quickstart](snowflake-quickstart.md)
+if Snowflake objects are missing, or [First run](../tutorial/first-run.md) if
+Snowflake is already ready.

--- a/docs/getting-started/snowflake-quickstart.md
+++ b/docs/getting-started/snowflake-quickstart.md
@@ -186,11 +186,12 @@ This validates the resolved EvSnow configuration and control-table access. Keep
 the Snowflake object checks above as the proof that the Iceberg table, pipe, and
 pipe grants exist.
 
-Treat any warning as a setup failure even if the command exits `0`. In
-particular, `Warning: Could not verify Snowflake control table` means the
-runtime role still lacks the control-table privileges needed by validation.
-The expected success marker is
-`Snowflake control table verified/created successfully` with no warnings.
+Do not rely only on the process exit code. Treat any validation error or warning
+as a setup failure even if the command exits `0`. In particular,
+`Warning: Could not verify Snowflake control table` means the runtime role still
+lacks the control-table privileges needed by validation. The expected success
+marker is `Snowflake control table verified/created successfully` with no
+warnings.
 
 After validation passes without warnings, continue with
 [First run](../tutorial/first-run.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,14 @@ table, and a repeatable local smoke test.
 Go to [First run](tutorial/first-run.md) to install EvSnow, configure one local
 pipeline, validate the settings, and run it.
 
+[Start first run](tutorial/first-run.md){ .md-button .md-button--primary }
+[Set up Event Hub](getting-started/event-hub-quickstart.md){ .md-button }
+[Set up Snowflake](getting-started/snowflake-quickstart.md){ .md-button }
+
 ## Other Paths
 
 - Set up Snowflake from scratch: [Snowflake quickstart](getting-started/snowflake-quickstart.md)
+- Set up Azure Event Hubs from scratch: [Event Hub quickstart](getting-started/event-hub-quickstart.md)
 - Configure key-pair authentication: [Snowflake key-pair auth](snowflake/key-pair-auth.md)
 - Tune runtime settings: [Configuration](configuration.md)
 - Check every Snowflake object and grant: [Complete Snowflake setup](snowflake/complete-setup.md)

--- a/docs/project/workflows.md
+++ b/docs/project/workflows.md
@@ -34,6 +34,7 @@ Runs the main quality and test pipeline.
 - Unit and integration tests
 - Coverage summary and PR coverage comment
 - Docker build job is present but disabled in the workflow
+- Published releases trigger the same checks; they do not publish Docker images
 
 Manual run:
 
@@ -48,12 +49,13 @@ GitHub Pages after changes land on `main`.
 
 - Dependency install: `uv sync --group docs --locked`
 - Build command: `uv run zensical build --clean --strict`
-- Artifact path: `site`
+- Artifact path: `site`, uploaded by the build job on pushes to `main`
 - Deploy target: GitHub Pages environment
 - Live site: `https://miguelelgallo.github.io/evsnow/`
 
 The deploy job only runs on pushes to `main`. Pull requests build the site but
-do not publish it.
+do not publish it. The deploy job publishes the artifact from the build job; it
+does not rebuild the documentation.
 
 Manual run:
 
@@ -63,6 +65,49 @@ gh workflow run docs.yml
 
 Manual runs build the docs only. Deployment happens after a push or merge to
 `main`, because the deploy job is gated to push events.
+
+### CodSpeed (`.github/workflows/codspeed.yml`)
+
+Runs benchmark tests through CodSpeed on pull requests, pushes to `main`, and
+manual dispatch.
+
+- Python version: `3.13`
+- Dependency install: `uv sync --all-groups`
+- Benchmark command: `uv run pytest tests/benchmarks/ --codspeed`
+- CodSpeed mode: simulation
+
+Treat CodSpeed failures as benchmark or instrumentation failures first. Normal
+unit and integration correctness is still covered by the Tests and CI/CD
+workflows.
+
+Manual run:
+
+```bash
+gh workflow run codspeed.yml
+```
+
+### End-To-End Quickstart Audit
+
+Use the quickstart harness when docs or setup SQL changes could affect a fresh
+Snowflake setup. The harness copies the repo to `.quickstart-runs/`, executes
+the quickstart commands, and writes every command plus stdout and stderr to
+`commands.jsonl`.
+
+```bash
+uv run python tools/quickstart_harness.py --connection default
+```
+
+Use a named Snowflake CLI setup connection when the default is not the account
+you want to audit:
+
+```bash
+uv run python tools/quickstart_harness.py --connection <setup-connection>
+```
+
+The acceptance gate is the generated summary reporting `passed`, plus a
+`validate EvSnow config` command with no validation errors or warning lines.
+The expected success marker is
+`Snowflake control table verified/created successfully`.
 
 ### Copilot Setup (`.github/workflows/copilot-setup-steps.yml`)
 
@@ -108,6 +153,21 @@ curl -fsSL "https://miguelelgallo.github.io/evsnow/reference/parameters/?v=<comm
 
 For other content-sensitive docs changes, search for one or two exact markers
 from the changed page in the live HTML before calling the publication complete.
+
+## Release Checks
+
+The release event runs CI/CD checks, but the workflow is not a publishing
+pipeline. Before creating a release, verify version values agree across
+`pyproject.toml`, `src/main.py`, `src/evsnow/__init__.py`, and version tests.
+
+After publishing a release:
+
+```bash
+gh release view <tag>
+gh run list --event release --limit 5
+```
+
+Report skipped Docker jobs separately from failed checks.
 
 ## Troubleshooting
 

--- a/docs/tools/eventhub-sender.md
+++ b/docs/tools/eventhub-sender.md
@@ -98,7 +98,8 @@ snow sql -x \
 For a 3-message smoke test, `rows_arrived` should be `3` and the
 `sequence_ids` should be consecutive.
 
-Use the Event Hub and target values from `config/evsnow.toml`. If you
-intentionally run with env-only shape, you can set `EVENTHUB_NAMESPACE`,
-`EVENTHUB_NAME`, `TARGET_DATABASE`, `TARGET_SCHEMA`, and `TARGET_TABLE` from
-the matching env variables instead.
+Use the Event Hub and target values from `config/evsnow.toml`. In the shell
+snippet above, `EVENTHUB_NAME` is only a local shell variable passed with
+`--eventhub`. If you intentionally run the sender with env-only shape and omit
+the flags, set `EVENTHUB_NAMESPACE` and `EVENTHUBNAME_1`, because the sender
+reads `EVENTHUBNAME_1` from `.env`.

--- a/docs/tutorial/first-run.md
+++ b/docs/tutorial/first-run.md
@@ -13,6 +13,9 @@ tutorial assumes the `STREAM` role, `STREAMEV` user, `CONTROL` database,
 - If the Snowflake objects do not exist yet, run
   [Snowflake quickstart](../getting-started/snowflake-quickstart.md), then come
   back here.
+- If the Event Hub namespace or Event Hub does not exist yet, run
+  [Event Hub quickstart](../getting-started/event-hub-quickstart.md), then come
+  back here.
 - If the objects already exist, continue below and create only the runtime
   files.
 
@@ -105,7 +108,9 @@ uv run evsnow validate-config --config-file config/evsnow.toml --env-file .env
 ```
 
 The Azure identity needs `Azure Event Hubs Data Receiver`. If you use the
-included sender utility, it also needs `Azure Event Hubs Data Sender`.
+included sender utility, it also needs `Azure Event Hubs Data Sender`. Use
+[Event Hub quickstart](../getting-started/event-hub-quickstart.md) when the
+namespace, Event Hub, or local RBAC grants do not exist yet.
 
 ## Dry Run
 
@@ -129,16 +134,56 @@ When startup succeeds, logs show the Event Hub name, Snowflake target, and
 Open terminal 2 and send test messages:
 
 ```bash
+RUN_ID="evsnow-first-run-$(date -u +%Y%m%dT%H%M%SZ)"
+START_ID=$(date -u +%s)
+
 uv run python tools/eventhub_sender/main.py \
   --namespace eventhub1.servicebus.windows.net \
   --eventhub topic1 \
   --count 3 \
-  --batch-size 3
+  --start-id "$START_ID" \
+  --batch-size 3 \
+  --partition-key "$RUN_ID" \
+  --payload "{\"run_id\":\"$RUN_ID\",\"purpose\":\"first-run\"}"
 ```
 
 Use the namespace and Event Hub name from `config/evsnow.toml`.
-Use [Event Hub sender](../tools/eventhub-sender.md) when you want a repeatable
-arrival check against Snowflake after the first pipeline starts cleanly.
+
+Then prove those messages reached Snowflake:
+
+```bash
+set -a
+source .env
+set +a
+
+TARGET_DATABASE=INGESTION
+TARGET_SCHEMA=PUBLIC
+TARGET_TABLE=EVENTS_TABLE1
+
+snow sql -x \
+  --account "$SNOWFLAKE_ACCOUNT" \
+  --user "$SNOWFLAKE_USER" \
+  --authenticator SNOWFLAKE_JWT \
+  --private-key-file "$SNOWFLAKE_PRIVATE_KEY_FILE" \
+  --role "$SNOWFLAKE_ROLE" \
+  --warehouse "$SNOWFLAKE_WAREHOUSE" \
+  --database "$TARGET_DATABASE" \
+  --schema "$TARGET_SCHEMA" \
+  --format JSON \
+  -q "SELECT COUNT(*) AS rows_arrived,
+             LISTAGG(TRY_PARSE_JSON(EVENT_BODY):sequence_id::STRING, ',')
+               WITHIN GROUP (ORDER BY TRY_PARSE_JSON(EVENT_BODY):sequence_id::NUMBER)
+             AS sequence_ids
+      FROM ${TARGET_DATABASE}.${TARGET_SCHEMA}.${TARGET_TABLE}
+      WHERE TRY_PARSE_JSON(EVENT_BODY):payload:run_id::STRING = '$RUN_ID';"
+```
+
+Snowpipe Streaming flush and consumer checkpoint timing are asynchronous. If
+the first query returns `rows_arrived = 0`, wait 15 seconds and rerun the same
+query while the pipeline is still running. The required proof is
+`rows_arrived = 3` and consecutive `sequence_ids`.
+Use [Event Hub sender](../tools/eventhub-sender.md) for the longer sender
+reference and repeatable arrival checks.
 
 ## What Happened
 

--- a/setup_snowflake.sql
+++ b/setup_snowflake.sql
@@ -140,4 +140,4 @@ VALUES
 DELETE FROM CONTROL.PUBLIC.INGESTION_STATUS WHERE EVENTHUB = 'test-eventhub';
 */
 
-SELECT 'Snowflake setup completed. Next: update .env, run uv run evsnow validate-config --show-rbac, then run setup_snowpipe_streaming.sql for high-performance streaming objects.' AS STATUS;
+SELECT 'Snowflake setup completed. Next: run setup_snowpipe_streaming.sql, update .env, then run uv run evsnow validate-config --show-rbac.' AS STATUS;

--- a/tests/unit/test_snowflake_internal_iceberg_setup.py
+++ b/tests/unit/test_snowflake_internal_iceberg_setup.py
@@ -9,12 +9,17 @@ SETUP_SQL = REPO_ROOT / "setup_snowpipe_streaming.sql"
 SETUP_GRANTS_SQL = REPO_ROOT / "setup_snowflake.sql"
 MESSAGES_CREATION_SQL = REPO_ROOT / "messages" / "creation.sql"
 QUICKSTART = REPO_ROOT / "docs" / "getting-started" / "snowflake-quickstart.md"
+EVENTHUB_QUICKSTART = REPO_ROOT / "docs" / "getting-started" / "event-hub-quickstart.md"
 COMPLETE_SETUP = REPO_ROOT / "docs" / "snowflake" / "complete-setup.md"
 PARAMETERS = REPO_ROOT / "docs" / "reference" / "parameters.md"
 QUICKSTART_HARNESS = REPO_ROOT / "tools" / "quickstart_harness.py"
 ENV_EXAMPLE = REPO_ROOT / ".env.example"
 CONFIGURATION = REPO_ROOT / "docs" / "configuration.md"
 ZENSICAL = REPO_ROOT / "zensical.toml"
+FIRST_RUN = REPO_ROOT / "docs" / "tutorial" / "first-run.md"
+EVENTHUB_SENDER = REPO_ROOT / "docs" / "tools" / "eventhub-sender.md"
+WORKFLOWS = REPO_ROOT / "docs" / "project" / "workflows.md"
+DOCS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "docs.yml"
 
 
 def _normalized(path: Path) -> str:
@@ -83,6 +88,7 @@ def test_setup_grants_include_iceberg_and_pipe_creation():
     assert "GRANT CREATE PIPE ON SCHEMA INGESTION.PUBLIC TO ROLE STREAM" in docs
     assert "TYPE = SERVICE" in docs
     assert "WARNING: COULD NOT VERIFY SNOWFLAKE CONTROL TABLE" in docs
+    assert "NEXT: RUN SETUP_SNOWPIPE_STREAMING.SQL, UPDATE .ENV" in grants
 
 
 def test_sample_message_creation_sql_uses_internal_storage():
@@ -121,6 +127,20 @@ def test_parameter_reference_covers_config_surfaces():
         assert term in docs
 
 
+def test_eventhub_quickstart_covers_creation_and_rbac():
+    docs = "\n".join(_normalized(path) for path in (EVENTHUB_QUICKSTART, FIRST_RUN))
+    config = _normalized(ZENSICAL)
+
+    assert "EVENT HUB QUICKSTART" in docs
+    assert "AZ EVENTHUBS NAMESPACE CREATE" in docs
+    assert "AZ EVENTHUBS EVENTHUB CREATE" in docs
+    assert "AZURE EVENT HUBS DATA RECEIVER" in docs
+    assert "AZURE EVENT HUBS DATA SENDER" in docs
+    assert "EVENTHUB-RBAC-SMOKE" in docs
+    assert "FULLY QUALIFIED NAMESPACE" in docs
+    assert "GETTING-STARTED/EVENT-HUB-QUICKSTART.MD" in config
+
+
 def test_env_example_keeps_first_run_shape_in_toml():
     active_keys = {
         line.split("=", 1)[0]
@@ -157,6 +177,37 @@ def test_zensical_enables_code_copy_buttons():
     config = ZENSICAL.read_text(encoding="utf-8")
 
     assert '"content.code.copy"' in config
+    assert '"search.highlight"' in config
+    assert "[project.markdown_extensions.attr_list]" in config
+    assert 'name = "mermaid"' in config
+
+
+def test_first_run_includes_arrival_proof():
+    docs = _normalized(FIRST_RUN)
+
+    assert "RUN_ID=\"EVSNOW-FIRST-RUN-" in docs
+    assert "ROWS_ARRIVED" in docs
+    assert "SEQUENCE_IDS" in docs
+    assert "WAIT 15 SECONDS AND RERUN" in docs
+    assert "ROWS_ARRIVED = 3" in docs
+
+
+def test_eventhub_sender_env_only_docs_match_cli_defaults():
+    docs = _normalized(EVENTHUB_SENDER)
+
+    assert "EVENTHUB_NAME` IS ONLY A LOCAL SHELL VARIABLE" in docs
+    assert "READS `EVENTHUBNAME_1` FROM `.ENV`" in docs
+
+
+def test_docs_workflow_deploys_built_artifact_once():
+    workflow = DOCS_WORKFLOW.read_text(encoding="utf-8")
+    docs = _normalized(WORKFLOWS)
+
+    assert "Upload GitHub Pages artifact" in workflow
+    assert "if: github.event_name == 'push'" in workflow
+    assert workflow.count("uv run zensical build --clean --strict") == 1
+    assert "DEPLOY JOB PUBLISHES THE ARTIFACT FROM THE BUILD JOB" in docs
+    assert "CODSPEED" in docs
 
 
 def test_quickstart_harness_fails_on_validation_warnings():
@@ -164,8 +215,14 @@ def test_quickstart_harness_fails_on_validation_warnings():
 
     assert 'os.environ.get("EVSNOW_QUICKSTART_CONNECTION", "default")' in harness
     assert "failure_patterns" in harness
+    assert "Configuration has errors" in harness
+    assert "Warnings:" in harness
+    assert "⚠" in harness
     assert "Warning: Could not verify Snowflake control table" in harness
     assert "Insufficient privileges" in harness
+    assert "SNOWFLAKE_DATABASE=INGESTION" not in harness
+    assert "SNOWFLAKE_SCHEMA_NAME=PUBLIC" not in harness
+    assert "database/schema are derived from config/evsnow.toml" in harness
 
 
 def test_quickstart_harness_resolves_cli_default_connection():

--- a/tools/quickstart_harness.py
+++ b/tools/quickstart_harness.py
@@ -230,8 +230,6 @@ class Harness:
                     f"SNOWFLAKE_PRIVATE_KEY_FILE={key_path}",
                     f"SNOWFLAKE_PRIVATE_KEY_PASSWORD={password}",
                     "SNOWFLAKE_WAREHOUSE=COMPUTE_WH",
-                    "SNOWFLAKE_DATABASE=INGESTION",
-                    "SNOWFLAKE_SCHEMA_NAME=PUBLIC",
                     "SNOWFLAKE_ROLE=STREAM",
                     "SNOWFLAKE_PIPE_NAME=EVENTS_TABLE_PIPE",
                     "",
@@ -239,7 +237,13 @@ class Harness:
             ),
             encoding="utf-8",
         )
-        self.note("create .env", "Created .env with generated key path and quickstart defaults.")
+        self.note(
+            "create .env",
+            (
+                "Created .env with generated key path and quickstart defaults. "
+                "The Snowflake session database/schema are derived from config/evsnow.toml."
+            ),
+        )
 
     def write_summary(self) -> None:
         first_failure = next((item for item in self.results if item.exit_code != 0), None)
@@ -342,6 +346,9 @@ class Harness:
                 "--config-file config/evsnow.toml --env-file .env"
             ),
             failure_patterns=[
+                "Configuration has errors",
+                "Warnings:",
+                "⚠",
                 "Warning: Could not verify Snowflake control table",
                 "Insufficient privileges",
                 "ERROR",

--- a/zensical.toml
+++ b/zensical.toml
@@ -17,6 +17,7 @@ nav = [
     "tutorial/first-run.md"
   ] },
   { "Setup" = [
+    "getting-started/event-hub-quickstart.md",
     "getting-started/snowflake-quickstart.md",
     "snowflake/key-pair-auth.md"
   ] },
@@ -60,6 +61,7 @@ features = [
   "content.action.edit",
   "content.action.view",
   "content.code.copy",
+  "search.highlight",
   "navigation.instant",
   "navigation.instant.progress",
   "navigation.tabs",
@@ -89,3 +91,19 @@ toggle.name = "Switch to light mode"
 
 [project.theme.icon]
 repo = "fontawesome/brands/github"
+
+[project.markdown_extensions.attr_list]
+
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+line_spans = "__span"
+pygments_lang_class = true
+
+[project.markdown_extensions.pymdownx.inlinehilite]
+
+[project.markdown_extensions.pymdownx.snippets]
+
+[project.markdown_extensions.pymdownx.superfences]
+custom_fences = [
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" }
+]


### PR DESCRIPTION
## Summary
- add an Event Hub quickstart and first-run Snowflake arrival proof
- enable Zensical search highlighting, button attributes, and Mermaid/code-block extensions
- align docs workflow with a single built Pages artifact and document CodSpeed/release/quickstart audit checks
- tighten the quickstart harness warning detection and align it with TOML-derived Snowflake session context

## Validation
- uv run zensical build --clean --strict
- uv run pytest -q
- uv run python tools/quickstart_harness.py --connection default
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/docs.yml')"
- local served docs marker checks on root, first-run, Event Hub quickstart, and workflows pages

Specialist review: Zensical GO, Documentation GO, PM/Auditor GO.